### PR TITLE
Feature: Shared Typography component

### DIFF
--- a/src/components/UI/Typography/Typography.tsx
+++ b/src/components/UI/Typography/Typography.tsx
@@ -1,0 +1,23 @@
+import { CSSProperties } from 'react';
+import { Text as MantineText, TextProps } from '@mantine/core';
+import { typographyVariants } from './styles';
+
+interface SharedTypographyProps extends Omit<TextProps, 'variant' | 'style'> {
+  variant?: keyof typeof typographyVariants;
+  children?: React.ReactNode;
+  style?: CSSProperties;
+}
+
+export const Typography = ({
+  style,
+  variant = 'primary',
+  children,
+  ...props
+}: SharedTypographyProps) => {
+  const variantStyle = typographyVariants[variant];
+  return (
+    <MantineText style={{ ...variantStyle, ...style }} {...props}>
+      {children}
+    </MantineText>
+  );
+};

--- a/src/components/UI/Typography/styles.ts
+++ b/src/components/UI/Typography/styles.ts
@@ -1,0 +1,21 @@
+import { theme } from '@/theme';
+
+const colors = theme.colors as Record<string, readonly string[]>;
+
+export const typographyVariants = {
+  primary: {
+    color: colors.primary[5],
+  },
+  secondary: {
+    color: colors.purple[5],
+  },
+  success: {
+    color: colors.success[5],
+  },
+  warning: {
+    color: colors.warning[5],
+  },
+  error: {
+    color: colors.error[5],
+  },
+};

--- a/src/components/UI/Typography/typography.story.tsx
+++ b/src/components/UI/Typography/typography.story.tsx
@@ -4,8 +4,11 @@ import { Typography } from './Typography';
 const meta: Meta<typeof Typography> = {
   title: 'Components/UI/Typography',
   component: Typography,
-  parameters: {
-    layout: 'centered',
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['primary', 'secondary', 'success', 'warning', 'error'],
+    },
   },
   tags: ['autodocs'],
 };
@@ -16,11 +19,11 @@ type Story = StoryObj<typeof meta>;
 export const typography: Story = {
   args: {
     children: 'Hello World!',
-    variant: 'warning',
+    variant: 'success',
   },
 };
 
-export const typographyWithH1: Story = {
+export const typographyWithChildren: Story = {
   render: () => (
     <Typography>
       <h1>Hello world!</h1>
@@ -30,5 +33,40 @@ export const typographyWithH1: Story = {
 export const typographyWithVariant: Story = {
   render: () => {
     return <Typography variant="error">Hello World!</Typography>;
+  },
+};
+
+export const typographyWithBodyText: Story = {
+  render: () => {
+    return (
+      <Typography>
+        Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has
+        been the industry's standard dummy text ever since the 1500s, when an unknown printer took a
+        galley of type and scrambled it to make a type specimen book. It has survived not only five
+        centuries, but also the leap into electronic typesetting, remaining essentially unchanged.
+        It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum
+        passages, and more recently with desktop publishing software like Aldus PageMaker including
+        versions of Lorem Ipsum
+      </Typography>
+    );
+  },
+};
+
+export const typographyWithTruncatedText: Story = {
+  render: (args) => {
+    return (
+      <Typography lineClamp={args.lineClamp}>
+        Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has
+        been the industry's standard dummy text ever since the 1500s, when an unknown printer took a
+        galley of type and scrambled it to make a type specimen book. It has survived not only five
+        centuries, but also the leap into electronic typesetting, remaining essentially unchanged.
+        It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum
+        passages, and more recently with desktop publishing software like Aldus PageMaker including
+        versions of Lorem Ipsum
+      </Typography>
+    );
+  },
+  args: {
+    lineClamp: 1,
   },
 };

--- a/src/components/UI/Typography/typography.story.tsx
+++ b/src/components/UI/Typography/typography.story.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Typography } from './Typography';
+
+const meta: Meta<typeof Typography> = {
+  title: 'Components/UI/Typography',
+  component: Typography,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const typography: Story = {
+  args: {
+    children: 'Hello World!',
+    variant: 'warning',
+  },
+};
+
+export const typographyWithH1: Story = {
+  render: () => (
+    <Typography>
+      <h1>Hello world!</h1>
+    </Typography>
+  ),
+};
+export const typographyWithVariant: Story = {
+  render: () => {
+    return <Typography variant="error">Hello World!</Typography>;
+  },
+};


### PR DESCRIPTION
https://github.com/Deadlink-Hunter/Broken-Link-Website/issues/12

So this would be a first version for that, I have few questions which I would love to get an answer on to make this better.

* Currently I only set the text color in the variants, do we have a set font weight for each one of them also? Otherwise you can set it manually through the style object.

* In terms of sizes, currently I allow Mantine`s size prop to be passed, I`m not sure if we are following the same sizes throughout this project? we might want to do it if we use this as the main styling library as it will be a bit of an headache to override this prop for each component with our own sizes

In another project I work on, We have a <ThemedText> component where in the variants, we care more about the sizes and weights than the colors as we already have a pallete which the consumer of this component can choose from, but we might want to have variants like "label", "title" etc which have their own font weight and size