### PR TITLE
typo fix in README.md Contributing Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To contribute:
     ```
 3.  Install dependencies using **pnpm** (please do not use npm or yarn):
     ```bash
-    npm install
+    pnpm install
     ```
 4.  Create a new branch for your feature or fix:
     ```bash


### PR DESCRIPTION
This PR updates the contributing instructions to use pnpm install instead of npm install, consistent with step 3.

Closes #67 