### PR TITLE
Fix PR welcome message typo: remove hyphen from 'double-check'

### DIFF
--- a/.github/workflows/pr-welcome.yml
+++ b/.github/workflows/pr-welcome.yml
@@ -18,7 +18,7 @@ jobs:
 
             We'll review it as soon as possible.
 
-            Before we proceed, please double-check:
+            Before we proceed, please double check:
             - The PR title & description clearly explain the changes.
             - All checks/tests pass.
             - You've linked it to an issue (if applicable).


### PR DESCRIPTION
Fix typo in PR welcome message