### PR TITLE
Add static Storybook serve script 

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "vitest": "vitest run",
     "vitest:watch": "vitest",
     "test": "pnpm run typecheck && pnpm run prettier && pnpm run lint && pnpm run vitest && pnpm run build",
-    "storybook": "storybook dev -p 6006",
-    "storybook:build": "storybook build"
+    "storybook": "npx storybook dev -p 6006",
+    "storybook:build": "npx storybook build",
+    "serve-storybook": "npx serve storybook-static -p 8080"
   },
   "dependencies": {
     "@mantine/core": "8.2.1",


### PR DESCRIPTION
Related to 


- Add new script "serve-storybook" in package.json to serve Storybook static build using npx serve
- Update "storybook" and "storybook:build" scripts to use npx for better cross-platform support
- No new dependencies added, keeps repo minimal and safe

Ready for review.
