### PR TITLE
Add serve-storybook script for static site serving

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "vitest:watch": "vitest",
     "test": "pnpm run typecheck && pnpm run prettier && pnpm run lint && pnpm run vitest && pnpm run build",
     "storybook": "storybook dev -p 6006",
-    "storybook:build": "storybook build"
+    "storybook:build": "storybook build",
+    "serve-storybook": "npx serve storybook-static -p 8080"
   },
   "dependencies": {
     "@mantine/core": "8.2.1",


### PR DESCRIPTION
Fixes #133 

-Added a new script `serve-storybook` to `package.json` that serves the built Storybook as a static website on port 8080.

## How to use
1. Build storybook: `npm run storybook:build`
2. Serve static site: `npm run serve-storybook`
3. Open http://localhost:8080

## Testing
- Tested locally - builds and serves successfully

@Tamir198  Please review when you get a chance!