### PR TITLE
refactor(icon): replace hardcoded identifiers with IconTypes enum

### DIFF
--- a/src/pages/About/components/FeaturesCards.tsx
+++ b/src/pages/About/components/FeaturesCards.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useMediaQuery } from '@mantine/hooks';
 import { FeatureCard } from './FeatureCard';
+import { IconType } from './IconTypes';
 import { bigContainerStyle, smallContainerStyle } from './styles';
 
 export const FeaturesCards = () => {
@@ -10,22 +11,22 @@ export const FeaturesCards = () => {
   return (
     <div style={bigScreen ? bigContainerStyle : smallContainerStyle}>
       <FeatureCard
-        icon='iconTarget'
+        icon={IconType.Target}
         title={t('about_feature_card.card_one.title')}
         description={t('about_feature_card.card_one.description')}
       />
       <FeatureCard
-        icon='iconFile'
+        icon={IconType.File}
         title={t('about_feature_card.card_two.title')}
         description={t('about_feature_card.card_two.description')}
       />
       <FeatureCard
-        icon='iconArrowGuide'
+        icon={IconType.ArrowGuide}
         title={t('about_feature_card.card_three.title')}
         description={t('about_feature_card.card_three.description')}
       />
       <FeatureCard
-        icon='iconBracketsAngle'
+        icon={IconType.BracketsAngle}
         title={t('about_feature_card.card_four.title')}
         description={t('about_feature_card.card_four.description')}
       />

--- a/src/pages/About/components/Icon.tsx
+++ b/src/pages/About/components/Icon.tsx
@@ -1,5 +1,6 @@
 import { IconArrowGuide, IconBracketsAngle, IconFile, IconTarget } from '@tabler/icons-react';
 import { theme } from '@/theme';
+import { IconType } from './IconTypes';
 import { iconStyle } from './styles';
 
 export const Icon = ({ icon }: { icon: string }) => {
@@ -7,13 +8,13 @@ export const Icon = ({ icon }: { icon: string }) => {
   const size = 50;
 
   switch (icon) {
-    case 'iconTarget':
+    case IconType.Target:
       return <IconTarget color={color} style={iconStyle} size={size} />;
-    case 'iconFile':
+    case IconType.File:
       return <IconFile color={color} style={iconStyle} size={size} />;
-    case 'iconArrowGuide':
+    case IconType.ArrowGuide:
       return <IconArrowGuide color={color} style={iconStyle} size={size} />;
-    case 'iconBracketsAngle':
+    case IconType.BracketsAngle:
       return <IconBracketsAngle color={color} style={iconStyle} size={size} />;
     default:
       return <IconTarget color={color} style={iconStyle} size={size} />;

--- a/src/pages/About/components/IconTypes.ts
+++ b/src/pages/About/components/IconTypes.ts
@@ -1,0 +1,6 @@
+export enum IconType {
+  Target = 'iconTarget',
+  File = 'iconFile',
+  ArrowGuide = 'iconArrowGuide',
+  BracketsAngle = 'iconBracketsAngle',
+}


### PR DESCRIPTION
Hi, I'm new to open source and this is my first contribution! 

This PR fixes the enum issue in the About page components:
- Updated FeaturesCards.tsx
- Updated Icon.tsx
- Added IconTypes.ts

I'm happy to receive any feedback and improve my contribution.