### PR TITLE
docs: remove hand icon from README and README-PT-BR

### DIFF
--- a/README-PT-BR.md
+++ b/README-PT-BR.md
@@ -42,7 +42,7 @@ Para ver a interface, faça login.
 
 Para utilizar totalmente as funcionalidades de scanner, você **DEVE** rodar o servidor Backend localmente (ou conectar-se a uma instância implantada). O frontend se comunica com o backend para realizar a verificação real dos links.
 
-👉 **Obtenha o Backend aqui:** [Repositório Broken-Link-Checker](https://github.com/Deadlink-Hunter/Broken-Link-Checker)
+**Obtenha o Backend aqui:** [Repositório Broken-Link-Checker](https://github.com/Deadlink-Hunter/Broken-Link-Checker)
 
 -----
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In order to see the ui log in.
 
 To fully use the scanner features, you **MUST** run the Backend server locally (or connect to a deployed instance). The frontend communicates with the backend to perform the actual link checking.
 
-👉 **Get the Backend here:** [Broken-Link-Checker Repository](https://github.com/Deadlink-Hunter/Broken-Link-Checker)
+**Get the Backend here:** [Broken-Link-Checker Repository](https://github.com/Deadlink-Hunter/Broken-Link-Checker)
 
 ---
 


### PR DESCRIPTION
### What was changed
- Removed the hand icon from README as requested in the issue.

### Why
- Improves visual consistency and follows project guidelines.

Closes #220 