### PR TITLE
#223 removed 3 keys from all 45 language files

### DIFF
--- a/public/locals/ar.json
+++ b/public/locals/ar.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "مرحبًا بك في ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "يتضمن هذا المشروع Vite إعدادًا أساسيًا. إذا كنت تريد معرفة المزيد عن تكامل Mantine مع Vite، اتبع",
   "welcome_link_text": "هذا الدليل",
   "welcome_description_after_link": ". للبدء، قم بتحرير ملف pages/Home.page.tsx."
 }

--- a/public/locals/be.json
+++ b/public/locals/be.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "Сардэчна запрашаем у ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "Гэты стартавы праект Vite ўключае мінімальную наладу. Калі вы хочаце даведацца больш пра інтэграцыю Mantine + Vite, азнаёмцеся з",
   "welcome_link_text": "гэтай інструкцыяй",
   "welcome_description_after_link": ". Каб пачаць, адрэдагуйце файл pages/Home.page.tsx."
 }

--- a/public/locals/ben.json
+++ b/public/locals/ben.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "স্বাগতম ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "এই Vite প্রজেক্টে একটি মিনিমাল কনফিগারেশন রয়েছে। আপনি যদি Mantine এবং Vite এর ইন্টিগ্রেশন সম্পর্কে আরও জানতে চান, তাহলে অনুসরণ করুন",
   "welcome_link_text": "এই নির্দেশিকা",
   "welcome_description_after_link": "। শুরু করার জন্য pages/Home.page.tsx ফাইলটি সম্পাদনা করুন।"
 }

--- a/public/locals/bhoj.json
+++ b/public/locals/bhoj.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "स्वागत बा ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "ई Vite प्रोजेक्ट में न्यूनतम सेटअप बा। अगर रउरा Mantine आ Vite के इंटीग्रेशन के बारे में जादे जनना चाहतानी, त",
   "welcome_link_text": "एह गाइड",
   "welcome_description_after_link": "के देखीं। सुरुआत खातिर pages/Home.page.tsx फाइल एडिट करीं।"
 }

--- a/public/locals/ca.json
+++ b/public/locals/ca.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "Benvinguts a ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "Aquest projecte Vite inclou una configuració mínima. Si voleu aprendre més sobre la integració de Mantine i Vite, seguiu",
   "welcome_link_text": "aquesta guia",
   "welcome_description_after_link": ". Per començar, editeu l'arxiu pages/Home.page.tsx."
 }

--- a/public/locals/chin.json
+++ b/public/locals/chin.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "歡迎來到 ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "這個 Vite 專案包含最小設定。如果您想進一步了解 Mantine 和 Vite 的整合，請參閱",
   "welcome_link_text": "本指南",
   "welcome_description_after_link": "。要開始，請編輯 pages/Home.page.tsx 檔案。"
 }

--- a/public/locals/cs.json
+++ b/public/locals/cs.json
@@ -1,7 +1,4 @@
 {
-    "welcome_title": "Vítejte v ",
-    "welcome_highlight": "Mantine",
-    "welcome_description_before_link": "Tento startovací projekt Vite obsahuje minimální nastavení. Pokud se chcete dozvědět více o integraci Mantine s Vite, následujte",
     "welcome_link_text": "tento návod",
     "welcome_description_after_link": ". Pro začátek upravte soubor pages/Home.page.tsx."
 }

--- a/public/locals/de.json
+++ b/public/locals/de.json
@@ -1,7 +1,4 @@
 {
-    "welcome_title": "Willkommen bei ",
-    "welcome_highlight": "Mantine",
-    "welcome_description_before_link": "Dieses Starterprojekt mit Vite enthält eine minimale Konfiguration. Wenn du mehr über die Integration von Mantine + Vite erfahren möchtest, folge",
     "welcome_link_text": "dieser Anleitung",
     "welcome_description_after_link": ". Um loszulegen, bearbeite die Datei pages/Home.page.tsx."
 }

--- a/public/locals/es.json
+++ b/public/locals/es.json
@@ -1,7 +1,4 @@
 {
-    "welcome_title": "Bienvenidos a ",
-    "welcome_highlight": "Mantine",
-    "welcome_description_before_link": "Este proyecto Vite incluye una configuración minimal. Si quieren aprender más sobre la integración Mantine y Vite, sigan",
     "welcome_link_text": "esta guía",
     "welcome_description_after_link": ". Para empezar, editen el archivo pages/Home.page.tsx."
 }

--- a/public/locals/fa.json
+++ b/public/locals/fa.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "خوش آمدید به ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "این پروژه Vite شامل یک پیکربندی حداقلی است. اگر می‌خواهید بیشتر درباره ادغام Mantine و Vite بیاموزید، دنبال کنید",
   "welcome_link_text": "این راهنما",
   "welcome_description_after_link": ". برای شروع، فایل pages/Home.page.tsx را ویرایش کنید."
 }

--- a/public/locals/fr.json
+++ b/public/locals/fr.json
@@ -1,7 +1,4 @@
 {
-    "welcome_title": "Bienvenue sur ",
-    "welcome_highlight": "Mantine",
-    "welcome_description_before_link": "Ce projet de démarrage avec Vite inclut une configuration minimale. Si vous souhaitez en savoir plus sur l’intégration Mantine + Vite, consultez",
     "welcome_link_text": "ce guide",
     "welcome_description_after_link": ". Pour commencer, modifiez le fichier pages/Home.page.tsx."
 }

--- a/public/locals/ger.json
+++ b/public/locals/ger.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "Bienvenidos a ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "Este proyecto Vite incluye una configuración minimal. Si quieren aprender más sobre la integración Mantine y Vite, sigan",
   "welcome_link_text": "esta guía",
   "welcome_description_after_link": ". Para empezar, editen el archivo pages/Home.page.tsx."
 }

--- a/public/locals/gr.json
+++ b/public/locals/gr.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "Καλώς ήρθατε στο ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "Αυτό το έργο Vite περιλαμβάνει μια ελάχιστη ρύθμιση. Αν θέλετε να μάθετε περισσότερα για την ενσωμάτωση Mantine και Vite, ακολουθήστε",
   "welcome_link_text": "αυτόν τον οδηγό",
   "welcome_description_after_link": ". Για να ξεκινήσετε, επεξεργαστείτε το αρχείο pages/Home.page.tsx."
 }

--- a/public/locals/guj.json
+++ b/public/locals/guj.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "સ્વાગત છે ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "આ Vite પ્રોજેક્ટમાં લઘુત્તમ રૂપરેખાંકન છે. જો તમે Mantine અને Vite ના એકીકરણ વિશે વધુ જાણવા માંગતા હો, તો",
   "welcome_link_text": "આ માર્ગદર્શિકા",
   "welcome_description_after_link": "અનુસરો. શરૂ કરવા માટે pages/Home.page.tsx ફાઇલ સંપાદિત કરો."
 }

--- a/public/locals/he.json
+++ b/public/locals/he.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "ברוכים הבאים ל ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "פרויקט Vite התחלתי זה כולל הגדרה מינימלית. אם תרצו ללמוד עוד על אינטגרציה של Mantine + Vite עקבו אחרי",
   "welcome_link_text": "המדריך הזה",
   "welcome_description_after_link": ". כדי להתחיל ערכו את הקובץ pages/Home.page.tsx."
 }

--- a/public/locals/heb.json
+++ b/public/locals/heb.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "ברוכים הבאים ל- ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "פרויקט Vite זה כולל הגדרה מינימלית. אם תרצו ללמוד עוד על שילוב Mantine ו-Vite, עקבו אחר",
   "welcome_link_text": "המדריך הזה",
   "welcome_description_after_link": ". כדי להתחיל, ערכו את הקובץ pages/Home.page.tsx."
 }

--- a/public/locals/hi.json
+++ b/public/locals/hi.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "स्वागत है ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "यह Vite प्रोजेक्ट एक न्यूनतम सेटअप शामिल करता है। यदि आप Mantine और Vite के एकीकरण के बारे में और जानना चाहते हैं, तो",
   "welcome_link_text": "इस गाइड",
   "welcome_description_after_link": "का पालन करें। शुरू करने के लिए pages/Home.page.tsx फ़ाइल को संपादित करें।"
 }

--- a/public/locals/hu.json
+++ b/public/locals/hu.json
@@ -1,7 +1,4 @@
 {
-    "welcome_title": "Üdvözöljük a ",
-    "welcome_highlight": "Mantine",
-    "welcome_description_before_link": "Ez a Vite kezdőprojekt egy minimális beállítást tartalmaz. Ha többet szeretnél megtudni a Mantine + Vite integrációról, kövesd",
     "welcome_link_text": "ezt az útmutatót",
     "welcome_description_after_link": ". A kezdéshez szerkeszd a pages/Home.page.tsx fájlt."
 }

--- a/public/locals/id.json
+++ b/public/locals/id.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "Selamat datang di ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "Proyek starter Vite ini sudah mencakup pengaturan minimal. Jika kamu ingin belajar lebih lanjut tentang integrasi Mantine + Vite, ikuti",
   "welcome_link_text": "panduan ini",
   "welcome_description_after_link": ". Untuk memulai, silakan edit file pages/Home.page.tsx."
 }

--- a/public/locals/it.json
+++ b/public/locals/it.json
@@ -1,7 +1,4 @@
 {
-    "welcome_title": "Benvenuto su ",
-    "welcome_highlight": "Mantine",
-    "welcome_description_before_link": "Questo progetto iniziale con Vite include una configurazione minima. Se desideri saperne di più sull’integrazione Mantine + Vite, consulta",
     "welcome_link_text": "questa guida",
     "welcome_description_after_link": ". Per iniziare, modifica il file pages/Home.page.tsx."
 }

--- a/public/locals/ja.json
+++ b/public/locals/ja.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "ようこそ ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "このプロジェクトには Vite の基本的な設定が含まれています。Mantine と Vite の統合について詳しく知りたい場合は、",
   "welcome_link_text": "このガイド",
   "welcome_description_after_link": "を参照してください。始めるには、pages/Home.page.tsx ファイルを編集してください。"
 }

--- a/public/locals/ka.json
+++ b/public/locals/ka.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "ಸ್ವಾಗತ ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "ಈ Vite ಯೋಜನೆಯಲ್ಲಿ ಕನಿಷ್ಠ ಸಂರಚನೆ ಸೇರಿಸಲಾಗಿದೆ. Mantine ಮತ್ತು Vite ಏಕೀಕರಣದ ಬಗ್ಗೆ ಇನ್ನಷ್ಟು ತಿಳಿಯಲು,",
   "welcome_link_text": "ಈ ಮಾರ್ಗದರ್ಶಿ",
   "welcome_description_after_link": "ಅನುಸರಿಸಿ. ಪ್ರಾರಂಭಿಸಲು pages/Home.page.tsx ಫೈಲ್ ಸಂಪಾದಿಸಿ."
 }

--- a/public/locals/kor.json
+++ b/public/locals/kor.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "환영합니다 ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "이 Vite 프로젝트에는 최소 설정이 포함되어 있습니다. Mantine과 Vite 통합에 대해 더 배우려면",
   "welcome_link_text": "이 가이드",
   "welcome_description_after_link": "를 따르세요. 시작하려면 pages/Home.page.tsx 파일을 수정하세요."
 }

--- a/public/locals/mar.json
+++ b/public/locals/mar.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "स्वागत आहे ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "या Vite प्रकल्पात किमान कॉन्फिगरेशन समाविष्ट आहे. तुम्हाला Mantine आणि Vite चे इंटिग्रेशन अधिक जाणून घ्यायचे असल्यास, कृपया",
   "welcome_link_text": "ही मार्गदर्शिका",
   "welcome_description_after_link": "पहा. सुरुवात करण्यासाठी pages/Home.page.tsx फाईल संपादित करा."
 }

--- a/public/locals/ms.json
+++ b/public/locals/ms.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "Selamat datang ke ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "Projek Vite ini termasuk konfigurasi minimal. Jika anda ingin belajar lebih lanjut mengenai integrasi Mantine dan Vite, ikuti",
   "welcome_link_text": "panduan ini",
   "welcome_description_after_link": ". Untuk memulakan, sunting fail pages/Home.page.tsx."
 }

--- a/public/locals/nl.json
+++ b/public/locals/nl.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "Welkom bij ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "Dit Vite-project bevat een minimale configuratie. Als je meer wilt leren over de integratie van Mantine en Vite, volg",
   "welcome_link_text": "deze gids",
   "welcome_description_after_link": ". Om te beginnen, bewerk het bestand pages/Home.page.tsx."
 }

--- a/public/locals/no.json
+++ b/public/locals/no.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "Velkommen til ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "Dette Vite-prosjektet inkluderer en minimal konfigurasjon. Hvis du vil lære mer om integrering av Mantine og Vite, følg",
   "welcome_link_text": "denne guiden",
   "welcome_description_after_link": ". For å komme i gang, rediger filen pages/Home.page.tsx."
 }

--- a/public/locals/or.json
+++ b/public/locals/or.json
@@ -1,7 +1,4 @@
 {
-"welcome_title": "ସ୍ୱାଗତ",
-"welcome_highlight": "Mantine",
-"welcome_description_before_link": "ଏହି ଷ୍ଟାର୍ଟର୍ Vite ପ୍ରୋଜେକ୍ଟରେ ଏକ ସର୍ବନିମ୍ନ ସେଟଅପ୍ ଅନ୍ତର୍ଭୁକ୍ତ। ଯଦି ଆପଣ Mantine + Vite ଇଣ୍ଟିଗ୍ରେସନ୍ ବିଷୟରେ ଅଧିକ ଜାଣିବାକୁ ଚାହାଁନ୍ତି ତେବେ ଅନୁସରଣ କରନ୍ତୁ",
 "welcome_link_text": "ଏହି ମାର୍ଗଦର୍ଶିକା",
 "welcome_description_after_link": "। ଆରମ୍ଭ କରିବାକୁ pages/Home.page.tsx ଫାଇଲ୍ ସମ୍ପାଦନ କରନ୍ତୁ।"
 }

--- a/public/locals/pa.json
+++ b/public/locals/pa.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "ਵੈਲਕਮ ਟੂ ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "ਇਹ Vite ਪ੍ਰੋਜੈਕਟ ਘੱਟੋ-ਘੱਟ ਸੰਰਚਨਾ ਨਾਲ ਆਇਆ ਹੈ। ਜੇ ਤੁਸੀਂ Mantine ਅਤੇ Vite ਇਕਠੇ ਕਰਨ ਬਾਰੇ ਹੋਰ ਸਿੱਖਣਾ ਚਾਹੁੰਦੇ ਹੋ ਤਾਂ ਇਸਨੂੰ ਫੋਲੋ ਕਰੋ",
   "welcome_link_text": "ਇਸ ਗਾਈਡ ਨੂੰ",
   "welcome_description_after_link": ". ਸ਼ੁਰੂ ਕਰਨ ਲਈ pages/Home.page.tsx ਫਾਈਲ ਨੂੰ ਸੰਪਾਦਿਤ ਕਰੋ।"
 }

--- a/public/locals/ph.json
+++ b/public/locals/ph.json
@@ -1,7 +1,4 @@
 {
-    "welcome_title": "Maligayang pagdating sa ",
-    "welcome_highlight": "Mantine",
-    "welcome_description_before_link": "Ito ay isang pang baguhan na proyekto gamit ang Vite na may minimal na setup. Kung nais mong matuto nang higit pa tungkol sa integrasyon ng Mantine + Vite sundan mo ang proyektong ito",
     "welcome_link_text": "itong gabay",
     "welcome_description_after_link": ". Upang makapagsimula, baguhin ang pages/Home.page.tsx file."
 }

--- a/public/locals/pl.json
+++ b/public/locals/pl.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "Witamy w ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "Ten początkowy projekt Vite zawiera minimalną konfigurację. Jeśli chcesz dowiedzieć się więcej o integracji Mantine + Vite, zapoznaj się z",
   "welcome_link_text": "tym przewodnikiem",
   "welcome_description_after_link": ". Aby rozpocząć, edytuj plik pages/Home.page.tsx."
 }

--- a/public/locals/po.json
+++ b/public/locals/po.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "Witamy w ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "Ten projekt Vite zawiera minimalną konfigurację. Jeśli chcesz dowiedzieć się więcej o integracji Mantine i Vite, postępuj zgodnie z",
   "welcome_link_text": "tym przewodnikiem",
   "welcome_description_after_link": ". Aby rozpocząć, edytuj plik pages/Home.page.tsx."
 }

--- a/public/locals/ptbr.json
+++ b/public/locals/ptbr.json
@@ -1,7 +1,4 @@
 {
-    "welcome_title": "Bem-vindo ao ",
-    "welcome_highlight": "Mantine",
-    "welcome_description_before_link": "Este projeto inicial com o Vite inclui uma configuração mínima. Se quiser saber mais sobre a integração Mantine + Vite, siga",
     "welcome_link_text": "esta guia",
     "welcome_description_after_link": ". Para começar, edite o arquivo pages/Home.page.tsx."
 }

--- a/public/locals/ro.json
+++ b/public/locals/ro.json
@@ -1,7 +1,4 @@
 {
-    "welcome_title": "Bun venit pe ",
-    "welcome_highlight": "Mantine",
-    "welcome_description_before_link": "Acest proiect de incepatori Vite include configuratie minimalista. Daca doresti sa afli mai multe despre integrarea Mantine + Vite, urmareste",
     "welcome_link_text": "acest ghid",
     "welcome_description_after_link": ". Pentru a incepe, editeaza fisierul pages/Home.page.tsx ."
 }

--- a/public/locals/ru.json
+++ b/public/locals/ru.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "Добро пожаловать на ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "Этот стартовый проект на Vite содержит минимальную настройку. Если вы хотите узнать больше об интеграции Mantine и Vite, перейдите по ссылке",
   "welcome_link_text": "этот гайд",
   "welcome_description_after_link": ". Чтобы начать, отредактируйте файл pages/Home.page.tsx"
 }

--- a/public/locals/sp.json
+++ b/public/locals/sp.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "Bienvenidos a ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "Este proyecto Vite incluye una configuración minimal. Si quieren aprender más sobre la integración Mantine y Vite, sigan",
   "welcome_link_text": "esta guía",
   "welcome_description_after_link": ". Para empezar, editen el archivo pages/Home.page.tsx."
 }

--- a/public/locals/sv.json
+++ b/public/locals/sv.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "Välkommen till ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "Detta Vite-projekt inkluderar en minimal konfiguration. Om du vill lära dig mer om integrationen av Mantine och Vite, följ",
   "welcome_link_text": "denna guide",
   "welcome_description_after_link": ". För att börja, redigera filen pages/Home.page.tsx."
 }

--- a/public/locals/sw.json
+++ b/public/locals/sw.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "Karibu kwenye ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "Mradi huu wa Vite unajumuisha usanidi wa chini kabisa. Ikiwa ungependa kujifunza zaidi kuhusu ujumuishaji wa Mantine na Vite, fuata",
   "welcome_link_text": "mwongozo huu",
   "welcome_description_after_link": ". Ili kuanza, hariri faili pages/Home.page.tsx."
 }

--- a/public/locals/tam.json
+++ b/public/locals/tam.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "வரவேற்பு ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "இந்த Vite திட்டத்தில் குறைந்தபட்ச கட்டமைப்பு உள்ளது. Mantine மற்றும் Vite ஒருங்கிணைப்பைப் பற்றி மேலும் அறிய விரும்பினால்,",
   "welcome_link_text": "இந்த வழிகாட்டியை",
   "welcome_description_after_link": "பின்பற்றவும். தொடங்க pages/Home.page.tsx கோப்பை திருத்தவும்."
 }

--- a/public/locals/tel.json
+++ b/public/locals/tel.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "స్వాగతం ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "ఈ Vite ప్రాజెక్ట్ కనీస కాన్ఫిగరేషన్‌ను కలిగి ఉంది. మీరు Mantine మరియు Vite యొక్క సమీకరణం గురించి మరింత తెలుసుకోవాలనుకుంటే,",
   "welcome_link_text": "ఈ మార్గదర్శకాన్ని",
   "welcome_description_after_link": "అనుసరించండి. ప్రారంభించడానికి pages/Home.page.tsx ఫైల్‌ను సవరించండి."
 }

--- a/public/locals/thai.json
+++ b/public/locals/thai.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "ยินดีต้อนรับสู่ ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "โปรเจกต์ Vite นี้มีการตั้งค่าขั้นพื้นฐาน หากคุณต้องการเรียนรู้เพิ่มเติมเกี่ยวกับการผสานรวม Mantine และ Vite โปรดดู",
   "welcome_link_text": "คู่มือนี้",
   "welcome_description_after_link": "เพื่อเริ่มต้น แก้ไขไฟล์ pages/Home.page.tsx"
 }

--- a/public/locals/tur.json
+++ b/public/locals/tur.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "Hoş geldiniz ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "Bu Vite projesi minimal bir yapılandırma içerir. Mantine ve Vite entegrasyonu hakkında daha fazla bilgi edinmek istiyorsanız,",
   "welcome_link_text": "bu kılavuzu",
   "welcome_description_after_link": "takip edin. Başlamak için pages/Home.page.tsx dosyasını düzenleyin."
 }

--- a/public/locals/uk.json
+++ b/public/locals/uk.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "Ласкаво просимо до ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "Цей стартовий проект на Vite містить в собі мінімальні налаштування. Якщо ви бажаєте дізнатися більше про інтеграцію Mantine та Vite, перейдіть за посиланням",
   "welcome_link_text": "цей гайд",
   "welcome_description_after_link": ". Щоб почати, відредагуйте файл pages/Home.page.tsx"
 }

--- a/public/locals/ur.json
+++ b/public/locals/ur.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "خوش آمدید ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "یہ ابتدائی Vite پروجیکٹ ایک سادہ سیٹ اپ کے ساتھ آتا ہے۔ اگر آپ Mantine اور Vite کے انضمام کے بارے میں مزید جاننا چاہتے ہیں تو براہ کرم",
   "welcome_link_text": "یہ رہنمائی دیکھیں",
   "welcome_description_after_link": "۔ شروعات کرنے کے لیے pages/Home.page.tsx فائل میں ترمیم کریں۔"
 }

--- a/public/locals/viet.json
+++ b/public/locals/viet.json
@@ -1,7 +1,4 @@
 {
-  "welcome_title": "Chào mừng đến với ",
-  "welcome_highlight": "Mantine",
-  "welcome_description_before_link": "Dự án Vite này bao gồm một cấu hình tối thiểu. Nếu bạn muốn tìm hiểu thêm về việc tích hợp Mantine và Vite, hãy theo dõi",
   "welcome_link_text": "hướng dẫn này",
   "welcome_description_after_link": ". Để bắt đầu, hãy chỉnh sửa tệp pages/Home.page.tsx."
 }


### PR DESCRIPTION
 "welcome_title": "Welcome to ",
  "welcome_highlight": "Mantine",
  "welcome_description_before_link": "This starter Vite project includes a minimal setup. If you want to learn more on Mantine + Vite integration follow",
  
  
  removed these keys from all 45 language files other than en.json