### PR TITLE
ExploreToolkit.module.css remove comment

### DIFF
--- a/src/pages/Home/Components/ExploreToolkit.module.css
+++ b/src/pages/Home/Components/ExploreToolkit.module.css
@@ -1,4 +1,3 @@
-/* TODO: Convert this file to a .styles.ts file */
 /* TODO Make sure that there are no inline styles in here and everything will come from the theme */
 .title {
   color: light-dark(var(--mantine-color-black), var(--mantine-color-white));


### PR DESCRIPTION

**Title**
`ExploreToolkit.module.css: remove obsolete TODO comment`

**Description**
Removed the outdated TODO comment from `ExploreToolkit.module.css` (`/* TODO: Convert this file to a .styles.ts file */`) since it’s no longer relevant. T

**Issue**
Fixes #217

