### PR TITLE
feat(statistics): add title and subtitle to statistics page

### DIFF
--- a/public/locals/en.json
+++ b/public/locals/en.json
@@ -80,5 +80,10 @@
   "explore_toolkit_card3_description": "Learn more about the mission behind Deadlink-Hunter, its open-source nature, and how you can contribute.",
   "explore_toolkit_card3_button": "Learn More",
   "our_mission_card_title": "Our Mission",
-  "our_mission_card_description": "To provide developers with a reliable, efficient, and easy-to-use solution for maintaining link integrity across their broken links shouldn't break user experiences, and every repository deserves to be link-perfect."
+  "our_mission_card_description": "To provide developers with a reliable, efficient, and easy-to-use solution for maintaining link integrity across their broken links shouldn't break user experiences, and every repository deserves to be link-perfect.",
+  "statistics_page": {
+    "title": "Statistics",
+    "description": "Overview of repository activity and link health"
+  }
 }
+

--- a/src/pages/Statistics/Statistics.page.tsx
+++ b/src/pages/Statistics/Statistics.page.tsx
@@ -1,9 +1,18 @@
+import { useTranslation } from 'react-i18next';
 import Charts from './components/Charts';
 import { pageContainer } from './components/styles';
+import TitleBanner from './components/TitleBanner';
 
 const StatisticsPage = () => {
+  const { t } = useTranslation();
+  const titleBannerText = {
+    title: t('statistics_page.title'),
+    description: t('statistics_page.description'),
+  };
+
   return (
     <div style={pageContainer}>
+      <TitleBanner text={titleBannerText} />
       <Charts />
     </div>
   );

--- a/src/pages/Statistics/components/TitleBanner.module.css
+++ b/src/pages/Statistics/components/TitleBanner.module.css
@@ -1,0 +1,33 @@
+.titleContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 5rem 0;
+}
+
+.title {
+  font-weight: 900;
+  line-height: 1.1;
+  font-size: 3rem;
+  letter-spacing: -0.04em;
+}
+
+.titleGradient {
+  background: linear-gradient(
+    90deg,
+    var(--mantine-color-cyan-4) 0%,
+    var(--mantine-color-purple-5) 100%
+  );
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.description {
+  font-family: var(--mantine-font-family);
+  font-weight: 500;
+  font-size: var(--mantine-font-size-xl);
+  line-height: 1.75;
+  letter-spacing: 0.02em;
+  padding-inline: var(--mantine-spacing-xl);
+}
+

--- a/src/pages/Statistics/components/TitleBanner.tsx
+++ b/src/pages/Statistics/components/TitleBanner.tsx
@@ -1,0 +1,25 @@
+import { Typography } from '@/components/UI/Typography/Typography';
+import classes from './TitleBanner.module.css';
+
+interface TitleBannerText {
+  title: string;
+  description: string;
+}
+
+interface TitleBannerProps {
+  text: TitleBannerText;
+}
+
+export default function TitleBanner({ text }: TitleBannerProps) {
+  return (
+    <div className={classes.titleContainer}>
+      <Typography variant='title' className={classes.title}>
+        <span className={classes.titleGradient}>{text.title}</span>
+      </Typography>
+      <Typography variant='tertiary' className={classes.description}>
+        {text.description}
+      </Typography>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary

Adds a title and subtitle banner to the Statistics page, matching the provided design and using i18n translations.

## Changes
- Added a `TitleBanner` component scoped to the Statistics page
- Added translated title and subtitle for the Statistics page
- Integrated the banner above existing charts

Closes #257