### PR TITLE
fix link hover color visibility in light mode

### DIFF
--- a/src/components/Navbar/styles.ts
+++ b/src/components/Navbar/styles.ts
@@ -23,8 +23,10 @@ export const desktopStyles = {
     justifyContent: 'center',
     alignItems: 'center',
   },
-  linkHoverColor: (isPathMatch: boolean) => (isPathMatch ? theme.colors.cyan[4] : theme.white),
-  linkColor: (isPathMatch: boolean) => (isPathMatch ? theme.colors.cyan[4] : theme.colors.gray[2]),
+  linkHoverColor: (isPathMatch: boolean) =>
+  isPathMatch ? theme.colors.cyan[5] : theme.colors.gray[7],
+
+  linkColor: (isPathMatch: boolean) => (isPathMatch ? theme.colors.cyan[4] : theme.colors.gray[4]),
   linkStyle: {
     fontWeight: 'bold',
     padding: '.77rem',


### PR DESCRIPTION
### Problem
In light mode, navbar links became invisible on hover due to a white hover color on a white background.

### Solution
Updated the navbar link hover color to a darker theme color to ensure proper contrast and visibility in light mode.

### Impact
- Fixes unreadable navbar links on hover
- No visual regressions in dark mode
