### PR TITLE
Fix: Add the link for documentation

### DIFF
--- a/src/constants/links.consts.ts
+++ b/src/constants/links.consts.ts
@@ -6,7 +6,7 @@ export const EXTERNAL_LINKS = {
     ISSUES: 'https://github.com/Deadlink-Hunter/Broken-Link-Website/issues',
     FEATURE_REQUEST: 'https://github.com/Deadlink-Hunter/Broken-Link-Website/issues/new?template=feature_request.md'
   },
-  DOCUMENTATION: '#'
+  DOCUMENTATION: 'https://github.com/memona008/Broken-Link-Website.git'
 } as const;
 
 export const NAVIGATION_LINKS = [


### PR DESCRIPTION
Add the documentation link. Now the Documentation link in Footer works as expected 
Closes #299 