### PR TITLE
Enable navigation from Explore Toolkit cards on Home page

### DIFF
--- a/src/pages/Home/Components/ExploreToolkit.tsx
+++ b/src/pages/Home/Components/ExploreToolkit.tsx
@@ -4,11 +4,13 @@ import { Card } from '@/components/UI/Card/Card';
 import { Typography } from '@/components/UI/Typography/Typography';
 import { useExploreToolkitCardsData } from './useExploreToolkitCardsData';
 import { exploreToolkitStyles } from './styles';
-import { LinkButton } from '@/components/UI/Button/LinkButton';
+import { Button } from '@/components/UI/Button/Button';
+import { useNavigate } from 'react-router-dom';
 
 export const ExploreToolkit = () => {
   const { t } = useTranslation();
   const { CARDS_DATA } = useExploreToolkitCardsData();
+  const navigate = useNavigate();
 
   return (
     <div style={exploreToolkitStyles.container}>
@@ -44,9 +46,9 @@ export const ExploreToolkit = () => {
             </div>
 
             {card.buttonTextKey && (
-              <LinkButton variant="primary" style={exploreToolkitStyles.cardButton} href={card.link}>
+              <Button variant="primary" style={exploreToolkitStyles.cardButton} onClick={() => navigate(card.link)}>
                 {card.buttonTextKey} <IconArrowRight size={18} />
-              </LinkButton>
+              </Button>
             )}
           </Card>
         ))}

--- a/src/pages/Home/Components/useExploreToolkitCardsData.ts
+++ b/src/pages/Home/Components/useExploreToolkitCardsData.ts
@@ -12,7 +12,7 @@ export const useExploreToolkitCardsData = () => {
       descriptionKey: t('explore_toolkit_card1_description'),
       buttonTextKey: t('explore_toolkit_card1_button'),
       icon: IconSearch,
-      link: '/Broken-Link-Website' + NAVIGATION_LINKS[1].href,
+      link: NAVIGATION_LINKS[1].href,
     },
     {
       id: 'card2',
@@ -20,7 +20,7 @@ export const useExploreToolkitCardsData = () => {
       descriptionKey: t('explore_toolkit_card2_description'),
       buttonTextKey: t('explore_toolkit_card2_button'),
       icon: IconChartHistogram,
-      link: '/Broken-Link-Website' + NAVIGATION_LINKS[2].href,
+      link: NAVIGATION_LINKS[2].href,
     },
     {
       id: 'card3',
@@ -28,7 +28,7 @@ export const useExploreToolkitCardsData = () => {
       descriptionKey: t('explore_toolkit_card3_description'),
       buttonTextKey: t('explore_toolkit_card3_button'),
       icon: IconInfoCircle,
-      link: '/Broken-Link-Website' + NAVIGATION_LINKS[3].href,
+      link: NAVIGATION_LINKS[3].href,
     },
   ];
 


### PR DESCRIPTION
Fixes #306 

**What’s changed**
This PR wires the three Explore Toolkit cards on the home page to their correct destinations:
- Instant Link Scanner → Scanner page
- Performance Analytics → Statistics page
- About the Project → About page