### PR TITLE
Handle SPA 404 refresh on GitHub Pages

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -10,37 +10,35 @@ import StatisticsPage from './pages/Statistics/Statistics.page';
 
 const withErrorBoundary = (element: React.ReactNode) => <ErrorBoundary>{element}</ErrorBoundary>;
 
-const router = createHashRouter(
-  [
-    {
-      path: ROUTES.HOME,
-      element: <AppLayout />,
-      errorElement: (
-        <ErrorBoundary>
-          <ErrorComponent />
-        </ErrorBoundary>
-      ),
-      children: [
-        {
-          index: true,
-          element: withErrorBoundary(<HomePage />),
-        },
-        {
-          path: ROUTES.ABOUT,
-          element: withErrorBoundary(<AboutPage />),
-        },
-        {
-          path: ROUTES.SCANNER,
-          element: withErrorBoundary(<ScannerPage />),
-        },
-        {
-          path: ROUTES.STATISTICS,
-          element: withErrorBoundary(<StatisticsPage />),
-        },
-      ],
-    },
-  ],
-);
+const router = createHashRouter([
+  {
+    path: ROUTES.HOME,
+    element: <AppLayout />,
+    errorElement: (
+      <ErrorBoundary>
+        <ErrorComponent />
+      </ErrorBoundary>
+    ),
+    children: [
+      {
+        index: true,
+        element: withErrorBoundary(<HomePage />),
+      },
+      {
+        path: ROUTES.ABOUT,
+        element: withErrorBoundary(<AboutPage />),
+      },
+      {
+        path: ROUTES.SCANNER,
+        element: withErrorBoundary(<ScannerPage />),
+      },
+      {
+        path: ROUTES.STATISTICS,
+        element: withErrorBoundary(<StatisticsPage />),
+      },
+    ],
+  },
+]);
 
 export function Router() {
   return <RouterProvider router={router} />;


### PR DESCRIPTION
**Summary**
Fixed the 404 error that occurs when refreshing pages on the deployed site.

 **Changes**
- Added `public/404.html` to handle GitHub Pages redirects.
- Added a script in `index.html` to restore the correct path.

 **Verification**
Tested on a deployed branch. Refreshing pages now works correctly without 404 errors.

Close #264 