### PR TITLE
refactor: ligth mode dark mode theme, typography and card styles on different themes

### DIFF
--- a/src/components/Charts/DonutChart/DonutChart.tsx
+++ b/src/components/Charts/DonutChart/DonutChart.tsx
@@ -1,11 +1,15 @@
 import { DonutChart as MantineDonutChart } from '@mantine/charts';
 import { Box } from '@mantine/core';
+import { useIsDark } from '@/components/Hooks/useIsDark';
 import { Typography } from '@/components/UI/Typography/Typography';
 import { DonutProps } from '../chart.types';
 import { CHART_COLORS } from '../data';
-import { chartStyles } from './styles';
+import { getChartStyles } from './styles';
 
 export default function DountChart({ data, withToolTip = false }: DonutProps) {
+  const isDark = useIsDark();
+  const chartStyles = getChartStyles(isDark);
+
   const graphData = data.map((item, i) => ({
     ...item,
     color: CHART_COLORS[i % CHART_COLORS.length],
@@ -15,17 +19,19 @@ export default function DountChart({ data, withToolTip = false }: DonutProps) {
       <MantineDonutChart
         withTooltip={withToolTip}
         data={graphData}
-        paddingAngle={chartStyles.paddingAngle}
-        thickness={chartStyles.thickness}
-        size={chartStyles.size}
-        strokeWidth={chartStyles.strokeWidth}
-        strokeColor={chartStyles.strokeColor}
+        paddingAngle={chartStyles.paddingAngle as number}
+        thickness={chartStyles.thickness as number}
+        size={chartStyles.size as number}
+        strokeWidth={chartStyles.strokeWidth as number}
+        strokeColor={chartStyles.strokeColor as string}
       />
-      <div style={chartStyles.labelsContainer}>
+      <div style={chartStyles.labelsContainer as React.CSSProperties}>
         {graphData.map((item, i) => (
-          <div key={item.name + i} style={chartStyles.labelsGap}>
-            <div style={chartStyles.labelColor(i)} />
-            <Typography style={chartStyles.labelText}>{item.name}</Typography>
+          <div key={item.name + i} style={chartStyles.labelsGap as React.CSSProperties}>
+            <div style={chartStyles.labelColor(i) as React.CSSProperties} />
+            <Typography style={chartStyles.labelText as React.CSSProperties}>
+              {item.name}
+            </Typography>
           </div>
         ))}
       </div>

--- a/src/components/Charts/DonutChart/styles.ts
+++ b/src/components/Charts/DonutChart/styles.ts
@@ -10,35 +10,36 @@ interface StylesObject {
   [key: string]: CSSProperties | string | number | StyleFunction;
 }
 
-export const chartStyles = {
-  container: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  paddingAngle: 4,
-  thickness: 70,
-  size: 250,
-  strokeWidth: 1,
-  strokeColor: theme.white,
-  labelsContainer: {
-    display: 'flex',
-    gap: '1rem',
-    paddingTop: '2rem',
-    marginTop: theme.spacing.md,
-  },
-  labelsGap: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing.md,
-  },
-  labelSize: 10,
-  labelColor: (colorIndex: number) => ({
-    borderRadius: '50%',
-    backgroundColor: CHART_COLORS[colorIndex % CHART_COLORS.length],
-    width: 10,
-    height: 10,
-  }),
-  labelText: { color: theme.white },
-} satisfies StylesObject;
+export const getChartStyles = (isDark: boolean) =>
+  ({
+    container: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    paddingAngle: 4,
+    thickness: 70,
+    size: 250,
+    strokeWidth: 1,
+    strokeColor: isDark ? theme.white : theme.colors.gray[3],
+    labelsContainer: {
+      display: 'flex',
+      gap: '1rem',
+      paddingTop: '2rem',
+      marginTop: theme.spacing.md,
+    },
+    labelsGap: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing.md,
+    },
+    labelSize: 10,
+    labelColor: (colorIndex: number) => ({
+      borderRadius: '50%',
+      backgroundColor: CHART_COLORS[colorIndex % CHART_COLORS.length],
+      width: 10,
+      height: 10,
+    }),
+    labelText: { color: isDark ? theme.white : theme.black },
+  }) satisfies StylesObject;

--- a/src/components/Navbar/DesktopNav.tsx
+++ b/src/components/Navbar/DesktopNav.tsx
@@ -1,16 +1,19 @@
 import { IconBrandGithub } from '@tabler/icons-react';
 import logo from '/logo.svg';
 import { useTranslation } from 'react-i18next';
+import { useIsDark } from '@/components/Hooks/useIsDark';
 import { useNavigationLinks } from '@/components/Hooks/useNavigationLinks';
 import { LinkButton, LinkTarget } from '../UI/Button/LinkButton';
 import { Link } from '../UI/Link/Link';
 import NavbarLinks from './NavbarLinks';
-import { desktopStyles as styles } from './styles';
+import { getDesktopStyles } from './styles';
 import { ThemeToggle } from './ThemeToggle';
 
 export default function DesktopNav() {
   const { externalLinks } = useNavigationLinks();
   const { t } = useTranslation();
+  const isDark = useIsDark();
+  const styles = getDesktopStyles(isDark);
   return (
     <div style={styles.container}>
       <div style={styles.headerContainer}>

--- a/src/components/Navbar/MobileNav.tsx
+++ b/src/components/Navbar/MobileNav.tsx
@@ -2,15 +2,18 @@ import { useState } from 'react';
 import logo from '/logo.svg';
 import { useTranslation } from 'react-i18next';
 import { Burger } from '@mantine/core';
+import { useIsDark } from '@/components/Hooks/useIsDark';
 import { Divider } from '../UI/Divider/Divider';
 import { Link } from '../UI/Link/Link';
 import NavbarLinks from './NavbarLinks';
-import { mobileStyles as styles } from './styles';
+import { getMobileStyles } from './styles';
 import { ThemeToggle } from './ThemeToggle';
 
 export default function MobileNav() {
   const { t } = useTranslation();
   const [displayLinks, setDisplayLinks] = useState(false);
+  const isDark = useIsDark();
+  const styles = getMobileStyles(isDark);
 
   function handleDisplayLinks() {
     setDisplayLinks((prev) => !prev);

--- a/src/components/Navbar/NavbarLink.tsx
+++ b/src/components/Navbar/NavbarLink.tsx
@@ -1,6 +1,7 @@
 import { useMatch, useResolvedPath } from 'react-router-dom';
+import { useIsDark } from '@/components/Hooks/useIsDark';
 import { Link } from '../UI/Link/Link';
-import { desktopStyles, mobileStyles } from './styles';
+import { getDesktopStyles, getMobileStyles } from './styles';
 
 interface NavbarLinkItemProps {
   href: string;
@@ -12,6 +13,9 @@ export default function NavbarLink({ href, label, variant }: NavbarLinkItemProps
   const resolvedPath = useResolvedPath(href);
   const match = useMatch({ path: resolvedPath.pathname, end: true });
   const isActive = Boolean(match);
+  const isDark = useIsDark();
+  const mobileStyles = getMobileStyles(isDark);
+  const desktopStyles = getDesktopStyles(isDark);
 
   if (variant === 'desktop') {
     return (

--- a/src/components/Navbar/NavbarLinks.tsx
+++ b/src/components/Navbar/NavbarLinks.tsx
@@ -1,12 +1,13 @@
 import { IconBrandGithub } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
-import { Divider, useMantineColorScheme } from '@mantine/core';
+import { Divider } from '@mantine/core';
+import { useIsDark } from '@/components/Hooks/useIsDark';
 import { useNavigationLinks } from '@/components/Hooks/useNavigationLinks';
 import { LinkButton, LinkTarget } from '../UI/Button/LinkButton';
 import { Typography } from '../UI/Typography/Typography';
 import { NavbarVariant } from './Navbar';
 import NavbarLink from './NavbarLink';
-import { mobileStyles } from './styles';
+import { getMobileStyles } from './styles';
 
 interface NavbarLinksProps {
   variant: NavbarVariant;
@@ -30,8 +31,8 @@ function Links({ variant }: LinksProps) {
 function MobileGithubBtn() {
   const { externalLinks } = useNavigationLinks();
   const { t } = useTranslation();
-  const { colorScheme } = useMantineColorScheme();
-  const isDark = colorScheme === 'dark';
+  const isDark = useIsDark();
+  const mobileStyles = getMobileStyles(isDark);
   return (
     <div style={mobileStyles.buttonContainer}>
       <LinkButton
@@ -40,7 +41,7 @@ function MobileGithubBtn() {
         variant='primary'
         style={mobileStyles.button}
       >
-        <IconBrandGithub color={mobileStyles.buttonIconColor(isDark)} size={16} />
+        <IconBrandGithub color={mobileStyles.buttonIconColor} size={16} />
         <Typography size='small' style={mobileStyles.buttonText}>
           {t('navbar.githubMobile')}
         </Typography>
@@ -50,6 +51,8 @@ function MobileGithubBtn() {
 }
 
 export default function NavbarLinks({ variant, displayLinks = true }: NavbarLinksProps) {
+  const isDark = useIsDark();
+  const mobileStyles = getMobileStyles(isDark);
   if (variant === 'desktop') {
     return <Links variant='desktop' />;
   }

--- a/src/components/Navbar/styles.ts
+++ b/src/components/Navbar/styles.ts
@@ -1,6 +1,6 @@
 import { theme } from '@/theme';
 
-export const desktopStyles = {
+export const getDesktopStyles = (isDark: boolean) => ({
   container: {
     width: '100%',
     display: 'flex',
@@ -18,9 +18,10 @@ export const desktopStyles = {
     alignItems: 'center',
   },
   linkHoverColor: (isPathMatch: boolean) =>
-    isPathMatch ? theme.colors.cyan[5] : theme.colors.gray[7],
+    isPathMatch ? theme.colors.cyan[5] : isDark ? theme.colors.gray[2] : theme.colors.gray[7],
 
-  linkColor: (isPathMatch: boolean) => (isPathMatch ? theme.colors.cyan[4] : theme.colors.gray[7]),
+  linkColor: (isPathMatch: boolean) =>
+    isPathMatch ? theme.colors.cyan[4] : isDark ? theme.colors.gray[2] : theme.colors.gray[7],
   linkStyle: {
     fontWeight: 'bold',
     padding: '.77rem',
@@ -32,9 +33,9 @@ export const desktopStyles = {
   buttonIcon: { marginRight: '1rem' },
   divider: { transform: 'scaleY(.1)' },
   buttonContainers: { display: 'flex', gap: '1rem' },
-};
+});
 
-export const mobileStyles = {
+export const getMobileStyles = (isDark: boolean) => ({
   container: {
     display: 'flex',
     alignItems: 'center',
@@ -51,9 +52,10 @@ export const mobileStyles = {
     fontWeight: '700',
     fontSize: '1rem',
   },
-  linkColor: (isPathMatch: boolean) => (isPathMatch ? theme.colors.cyan[4] : theme.colors.gray[7]),
+  linkColor: (isPathMatch: boolean) =>
+    isPathMatch ? theme.colors.cyan[4] : isDark ? theme.colors.gray[2] : theme.colors.gray[7],
   linkContainer: (isPathMatch: boolean) => ({
-    backgroundColor: isPathMatch ? '#1e293b' : 'transparent',
+    backgroundColor: isPathMatch ? (isDark ? '#1e293b' : theme.colors.gray[3]) : 'transparent',
     borderRadius: '8px',
     padding: '.6rem',
   }),
@@ -65,8 +67,8 @@ export const mobileStyles = {
     flex: 1,
     borderRadius: '4px',
   },
-  buttonIconColor: (isDark: boolean) => (isDark ? theme.colors.gray[2] : theme.colors.gray[7]),
-  buttonText: { margin: '0 .8rem', fontWeight: '700' },
+  buttonIconColor: theme.white,
+  buttonText: { margin: '0 .8rem', fontWeight: '700', color: theme.white },
 
   navDivider: {
     marginLeft: 'calc(50% - 50vw)',
@@ -74,6 +76,6 @@ export const mobileStyles = {
     transform: 'scaleY(.2)',
   },
   themeToggle: {
-    backround: 'red',
+    background: 'transparent',
   },
-};
+});

--- a/src/components/UI/Card/Card.tsx
+++ b/src/components/UI/Card/Card.tsx
@@ -1,6 +1,7 @@
 import { CSSProperties, ReactNode } from 'react';
 import { CardProps, Card as MantineCard } from '@mantine/core';
-import { cardStyles } from './styles';
+import { useIsDark } from '@/components/Hooks/useIsDark';
+import { getCardStyles } from './styles';
 
 interface SharedCardProps extends Omit<CardProps, 'style'> {
   style?: CSSProperties;
@@ -8,6 +9,9 @@ interface SharedCardProps extends Omit<CardProps, 'style'> {
 }
 
 export const Card = ({ children, className, style, ...props }: SharedCardProps) => {
+  const isDark = useIsDark();
+  const cardStyles = getCardStyles(isDark);
+
   const mergedStyle: CSSProperties = {
     ...cardStyles.default,
     ...style,

--- a/src/components/UI/Card/styles.ts
+++ b/src/components/UI/Card/styles.ts
@@ -4,7 +4,7 @@ import { theme } from '@/theme';
 
 const colors = theme.colors;
 
-export const cardStyles = {
+export const getCardStyles = (isDark: boolean) => ({
   default: {
     height: '100%',
     padding: theme.spacing.xl,
@@ -12,8 +12,11 @@ export const cardStyles = {
     flexDirection: 'column',
     justifyContent: 'space-between',
     borderRadius: 16,
-    backgroundColor: rgba(colors.primary[6], 0.5),
-    border: `1px solid ${rgba(colors.primary[2], 0.15)}`,
+    backgroundColor: isDark ? rgba(colors.primary[6], 0.5) : theme.white,
+    border: `1px solid ${isDark ? rgba(colors.primary[2], 0.15) : colors.primary[1]}`,
     backdropFilter: 'blur(12px)',
+    boxShadow: isDark
+      ? 'none'
+      : '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
   } satisfies CSSProperties,
-};
+});

--- a/src/components/UI/Typography/Typography.tsx
+++ b/src/components/UI/Typography/Typography.tsx
@@ -1,6 +1,7 @@
 import { CSSProperties } from 'react';
 import { Text as MantineText, TextProps } from '@mantine/core';
-import { typographyVariants } from './styles';
+import { useIsDark } from '@/components/Hooks/useIsDark';
+import { getTypographyVariants } from './styles';
 import { CustomSize } from './types';
 
 const sizeMapper: Record<CustomSize, string> = {
@@ -10,8 +11,10 @@ const sizeMapper: Record<CustomSize, string> = {
   extraLarge: 'xl',
 };
 
+type TypographyVariantKey = keyof ReturnType<typeof getTypographyVariants>;
+
 interface SharedTypographyProps extends Omit<TextProps, 'variant' | 'style' | 'size'> {
-  variant?: keyof typeof typographyVariants;
+  variant?: TypographyVariantKey;
   children?: React.ReactNode;
   style?: CSSProperties;
   size?: CustomSize;
@@ -25,6 +28,8 @@ export const Typography = ({
 
   ...props
 }: SharedTypographyProps) => {
+  const isDark = useIsDark();
+  const typographyVariants = getTypographyVariants(isDark);
   const variantStyle = typographyVariants[variant] ?? {};
   const resolvedSize = variantStyle.size ?? size;
   const mappedSize = sizeMapper[resolvedSize];

--- a/src/components/UI/Typography/styles.ts
+++ b/src/components/UI/Typography/styles.ts
@@ -3,15 +3,15 @@ import { CUSTOM_SIZES, TypographyVariant } from './types';
 
 const colors = theme.colors;
 
-export const typographyVariants: Record<string, TypographyVariant> = {
-  primary: { color: colors.primary[5] },
-  secondary: { color: colors.gray[5] },
-  tertiary: { color: colors.gray[4] },
+export const getTypographyVariants = (isDark: boolean): Record<string, TypographyVariant> => ({
+  primary: { color: isDark ? colors.primary[5] : colors.primary[7] },
+  secondary: { color: isDark ? colors.gray[5] : colors.gray[7] },
+  tertiary: { color: isDark ? colors.gray[4] : colors.gray[8] },
   cyan: { color: colors.cyan[5] },
   purple: { color: colors.purple[5] },
   success: { color: colors.success[5] },
   warning: { color: colors.warning[5] },
   error: { color: colors.error[5] },
-  title: { color: colors.primary[1], size: CUSTOM_SIZES.EXTRA_LARGE },
-  subtitle: { color: colors.primary[6], size: CUSTOM_SIZES.LARGE },
-};
+  title: { color: isDark ? colors.primary[1] : colors.primary[9], size: CUSTOM_SIZES.EXTRA_LARGE },
+  subtitle: { color: isDark ? colors.primary[6] : colors.primary[8], size: CUSTOM_SIZES.LARGE },
+});

--- a/src/pages/About/components/FeatureCard.tsx
+++ b/src/pages/About/components/FeatureCard.tsx
@@ -1,7 +1,8 @@
+import { useIsDark } from '@/components/Hooks/useIsDark';
 import { Card } from '@/components/UI/Card/Card';
 import { Typography } from '@/components/UI/Typography/Typography';
 import { Icon } from './Icon';
-import { featureCardStyles, paragraphStyle, titleStyle } from './styles';
+import { getFeatureCardStyles, getParagraphStyle, getTitleStyle } from './styles';
 
 export const FeatureCard = ({
   icon,
@@ -12,10 +13,15 @@ export const FeatureCard = ({
   title: string;
   description: string;
 }) => {
+  const isDark = useIsDark();
+  const featureCardStyles = getFeatureCardStyles(isDark);
+  const titleStyle = getTitleStyle(isDark);
+  const paragraphStyle = getParagraphStyle(isDark);
+
   return (
     <Card style={featureCardStyles}>
       <Icon icon={icon} />
-      <Typography variant='title' style={titleStyle}>
+      <Typography variant='primary' style={titleStyle}>
         {title}
       </Typography>
       <Typography variant='primary' style={paragraphStyle}>

--- a/src/pages/About/components/MissionCard.tsx
+++ b/src/pages/About/components/MissionCard.tsx
@@ -1,14 +1,19 @@
 import { useTranslation } from 'react-i18next';
+import { useIsDark } from '@/components/Hooks/useIsDark';
 import { Card } from '@/components/UI/Card/Card';
 import { Typography } from '@/components/UI/Typography/Typography';
-import { missionCardStyles, paragraphStyle, titleStyle } from './styles';
+import { getMissionCardStyles, getParagraphStyle, getTitleStyle } from './styles';
 
 export const MissionCard = () => {
   const { t } = useTranslation();
+  const isDark = useIsDark();
+  const missionCardStyles = getMissionCardStyles(isDark);
+  const titleStyle = getTitleStyle(isDark);
+  const paragraphStyle = getParagraphStyle(isDark);
 
   return (
     <Card style={missionCardStyles}>
-      <Typography variant='title' style={titleStyle}>
+      <Typography variant='primary' style={titleStyle}>
         {t('our_mission_card_title')}
       </Typography>
       <Typography variant='primary' style={paragraphStyle}>

--- a/src/pages/About/components/styles.ts
+++ b/src/pages/About/components/styles.ts
@@ -37,35 +37,35 @@ export const bigContainerStyle = {
   gridTemplateColumns: '1fr 1fr',
 };
 
-export const featureCardStyles = {
-  backgroundColor: colors.primary[8],
-  border: `1px solid ${colors.primary[9]}`,
-  boxShadow: `0 1px 3px ${colors.primary[1]}`,
+export const getFeatureCardStyles = (isDark: boolean) => ({
+  backgroundColor: isDark ? colors.primary[8] : theme.white,
+  border: `1px solid ${isDark ? colors.primary[9] : colors.primary[1]}`,
+  boxShadow: `0 1px 3px ${isDark ? colors.primary[1] : colors.primary[2]}`,
   padding: theme.spacing.lg,
   borderRadius: '0.5rem',
   display: 'grid',
   gridTemplateColumns: 'auto auto',
   gap: theme.spacing.lg,
-};
+});
 
-export const missionCardStyles: CSSProperties = {
-  backgroundColor: colors.primary[8],
-  border: `1px solid ${colors.primary[9]}`,
+export const getMissionCardStyles = (isDark: boolean): CSSProperties => ({
+  backgroundColor: isDark ? colors.primary[8] : theme.white,
+  border: `1px solid ${isDark ? colors.primary[9] : colors.primary[1]}`,
   padding: theme.spacing.xl,
   display: 'flex',
   flexDirection: 'column',
   textAlign: 'center',
   gap: theme.spacing.lg,
-};
+});
 
-export const titleStyle = {
-  color: colors.primary[1],
-};
+export const getTitleStyle = (isDark: boolean) => ({
+  color: isDark ? colors.primary[1] : theme.black,
+});
 
-export const paragraphStyle = {
-  color: colors.primary[2],
+export const getParagraphStyle = (isDark: boolean) => ({
+  color: isDark ? colors.primary[2] : colors.gray[7],
   gridColumnStart: 2,
-};
+});
 
 export const iconStyle = {
   gridRowEnd: 'span 2',

--- a/src/pages/Home/Components/ExploreToolkit.tsx
+++ b/src/pages/Home/Components/ExploreToolkit.tsx
@@ -1,16 +1,19 @@
 import { IconArrowRight } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { useIsDark } from '@/components/Hooks/useIsDark';
 import { Button } from '@/components/UI/Button/Button';
 import { Card } from '@/components/UI/Card/Card';
 import { Typography } from '@/components/UI/Typography/Typography';
-import { exploreToolkitStyles } from './styles';
+import { getExploreToolkitStyles } from './styles';
 import { useExploreToolkitCardsData } from './useExploreToolkitCardsData';
 
 export const ExploreToolkit = () => {
   const { t } = useTranslation();
   const { CARDS_DATA } = useExploreToolkitCardsData();
   const navigate = useNavigate();
+  const isDark = useIsDark();
+  const exploreToolkitStyles = getExploreToolkitStyles(isDark);
 
   return (
     <div style={exploreToolkitStyles.container}>

--- a/src/pages/Home/Components/HowItWorks/HowItWork.tsx
+++ b/src/pages/Home/Components/HowItWorks/HowItWork.tsx
@@ -1,11 +1,14 @@
-import { IconBolt, IconCircleCheck, IconSearch } from '@tabler/icons-react';
+import { IconBolt, IconCheck, IconSearch } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
+import { useIsDark } from '@/components/Hooks/useIsDark';
 import { HowItWorkCard } from './HowItWorkCard';
 import { HowItWorkTitles } from './HowItWorkTitles';
-import { cardIconStyles, howItWorksStyles } from './styles';
+import { cardIconStyles, getHowItWorksStyles } from './styles';
 
 export const HowItWork = () => {
   const { t } = useTranslation();
+  const isDark = useIsDark();
+  const howItWorksStyles = getHowItWorksStyles(isDark);
 
   return (
     <>
@@ -28,7 +31,7 @@ export const HowItWork = () => {
         <HowItWorkCard
           title={t('how_it_works_card3_title')}
           description={t('how_it_works_card3_description')}
-          icon={<IconCircleCheck size={40} />}
+          icon={<IconCheck size={40} />}
           stepNumber={3}
           iconStyle={cardIconStyles.fix}
         />

--- a/src/pages/Home/Components/HowItWorks/HowItWorkCard.tsx
+++ b/src/pages/Home/Components/HowItWorks/HowItWorkCard.tsx
@@ -1,7 +1,8 @@
 import { CSSProperties, ReactNode } from 'react';
+import { useIsDark } from '@/components/Hooks/useIsDark';
 import { Card } from '@/components/UI/Card/Card';
 import { Typography } from '@/components/UI/Typography/Typography';
-import { howItWorksStyles } from './styles';
+import { getHowItWorksStyles } from './styles';
 
 interface HowItWorkCardProps {
   title: string;
@@ -18,12 +19,19 @@ export const HowItWorkCard = ({
   stepNumber,
   iconStyle,
 }: HowItWorkCardProps) => {
+  const isDark = useIsDark();
+  const howItWorksStyles = getHowItWorksStyles(isDark);
+
   return (
     <Card style={howItWorksStyles.card}>
       <div style={howItWorksStyles.stepBadge}>{stepNumber}</div>
       <div style={iconStyle}>{icon}</div>
-      <Typography variant='title'>{title}</Typography>
-      <Typography variant='description'>{description}</Typography>
+      <Typography variant='primary' style={howItWorksStyles.cardTitle}>
+        {title}
+      </Typography>
+      <Typography variant='primary' style={howItWorksStyles.cardDescription}>
+        {description}
+      </Typography>
     </Card>
   );
 };

--- a/src/pages/Home/Components/HowItWorks/HowItWorkTitles.tsx
+++ b/src/pages/Home/Components/HowItWorks/HowItWorkTitles.tsx
@@ -1,18 +1,21 @@
 import { useTranslation } from 'react-i18next';
+import { useIsDark } from '@/components/Hooks/useIsDark';
 import { Typography } from '@/components/UI/Typography/Typography';
-import { howItWorksStyles } from './styles';
+import { getHowItWorksStyles } from './styles';
 
 export const HowItWorkTitles = () => {
   const { t } = useTranslation();
+  const isDark = useIsDark();
+  const howItWorksStyles = getHowItWorksStyles(isDark);
 
   return (
     <>
-      <Typography variant='h1' style={howItWorksStyles.title}>
+      <Typography variant='title' style={howItWorksStyles.title}>
         {t('how_it_works_title_part1')}
         <span style={howItWorksStyles.highlight}>{t('how_it_works_title_highlight')}</span>
         {t('how_it_works_title_part2')}
       </Typography>
-      <Typography variant='body' style={howItWorksStyles.description}>
+      <Typography variant='secondary' style={howItWorksStyles.description}>
         {t('how_it_works_subtitle')}
       </Typography>
     </>

--- a/src/pages/Home/Components/HowItWorks/styles.ts
+++ b/src/pages/Home/Components/HowItWorks/styles.ts
@@ -30,7 +30,7 @@ export const cardIconStyles = {
   },
 } satisfies Record<string, CSSProperties>;
 
-export const howItWorksStyles = {
+export const getHowItWorksStyles = (isDark: boolean) => ({
   container: {
     maxWidth: '75rem',
     margin: '0 auto',
@@ -38,7 +38,7 @@ export const howItWorksStyles = {
   } satisfies CSSProperties,
 
   title: {
-    color: `light-dark(${theme.black}, ${theme.white})`,
+    color: isDark ? theme.white : theme.black,
     fontWeight: 900,
     fontSize: '3.5rem',
     textAlign: 'center',
@@ -92,7 +92,7 @@ export const howItWorksStyles = {
   } satisfies CSSProperties,
 
   cardTitle: {
-    color: theme.white,
+    color: isDark ? theme.white : theme.black,
     fontWeight: 900,
     fontSize: '1.25rem',
     marginBottom: theme.spacing.sm,
@@ -100,8 +100,8 @@ export const howItWorksStyles = {
 
   cardDescription: {
     marginBottom: theme.spacing.xl,
-    color: rgba(theme.white, 0.72),
+    color: isDark ? rgba(theme.white, 0.72) : colors.gray[7],
     fontSize: '0.95rem',
     lineHeight: 1.6,
   } satisfies CSSProperties,
-};
+});

--- a/src/pages/Home/Components/styles.ts
+++ b/src/pages/Home/Components/styles.ts
@@ -4,7 +4,7 @@ import { theme } from '@/theme';
 
 const colors = theme.colors;
 
-export const exploreToolkitStyles = {
+export const getExploreToolkitStyles = (isDark: boolean) => ({
   container: {
     maxWidth: 1200,
     margin: '0 auto',
@@ -12,7 +12,7 @@ export const exploreToolkitStyles = {
   } satisfies CSSProperties,
 
   title: {
-    color: `light-dark(${theme.black}, ${theme.white})`,
+    color: isDark ? theme.white : theme.black,
     fontWeight: 900,
     fontSize: '3.5rem',
     textAlign: 'center',
@@ -54,7 +54,7 @@ export const exploreToolkitStyles = {
   } satisfies CSSProperties,
 
   cardTitle: {
-    color: theme.white,
+    color: isDark ? theme.white : theme.black,
     fontWeight: 900,
     fontSize: '1.25rem',
     marginBottom: theme.spacing.sm,
@@ -62,7 +62,7 @@ export const exploreToolkitStyles = {
 
   cardDescription: {
     marginBottom: theme.spacing.xl,
-    color: rgba(theme.white, 0.72),
+    color: isDark ? rgba(theme.white, 0.72) : colors.gray[7],
     fontSize: '0.95rem',
     lineHeight: 1.6,
   } satisfies CSSProperties,
@@ -73,10 +73,10 @@ export const exploreToolkitStyles = {
     backgroundColor: 'transparent',
     border: 'none',
 
-    color: colors.cyan[4],
+    color: isDark ? colors.cyan[4] : colors.cyan[7],
     fontWeight: 600,
     display: 'inline-flex',
     alignItems: 'center',
     gap: 8,
   } satisfies CSSProperties,
-};
+});

--- a/src/pages/Scanner/Scanner.page.tsx
+++ b/src/pages/Scanner/Scanner.page.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import { useMediaQuery } from '@mantine/hooks';
+import { useIsDark } from '@/components/Hooks/useIsDark';
 import { theme } from '@/theme';
 import { ScanLinksCard } from './components/ScanLinksCard';
 import { ScanResultsCard } from './components/ScanResultsCard';
 import { ScanTitlePage } from './components/ScanTitle';
-import { scanPageStyle } from './components/styles';
+import { getScanPageStyle } from './components/styles';
 import { ScanMode } from './types/scan';
 
 const ScannerPage = () => {
@@ -13,6 +14,8 @@ const ScannerPage = () => {
   const [multipleUrl, setMultipleUrl] = useState('');
 
   const isMobile = useMediaQuery(`(max-width: ${theme.breakpoints.md})`);
+  const isDark = useIsDark();
+  const scanPageStyle = getScanPageStyle(isDark);
 
   const cardsContainerStyle = isMobile
     ? scanPageStyle.scanCardsContainerMobile

--- a/src/pages/Scanner/components/RepositoryScanForm.tsx
+++ b/src/pages/Scanner/components/RepositoryScanForm.tsx
@@ -1,8 +1,9 @@
 import { ChangeEvent, FormEvent } from 'react';
 import { IconUpload } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
+import { useIsDark } from '@/components/Hooks/useIsDark';
 import { Button } from '@/components/UI/Button/Button';
-import { scanPageStyle } from './styles';
+import { getScanPageStyle } from './styles';
 
 interface RepositoryScanFormProps {
   url: string;
@@ -20,6 +21,8 @@ export const RepositoryScanForm = ({
   onSubmit,
 }: RepositoryScanFormProps) => {
   const { t } = useTranslation();
+  const isDark = useIsDark();
+  const scanPageStyle = getScanPageStyle(isDark);
   const baseTranslationKey = 'scanner_page.scan_links_card.repository';
 
   const handleSubmit = (e?: FormEvent<HTMLFormElement>) => {

--- a/src/pages/Scanner/components/ScanLinksCard.tsx
+++ b/src/pages/Scanner/components/ScanLinksCard.tsx
@@ -7,7 +7,7 @@ import { Typography } from '@/components/UI/Typography/Typography';
 import { ScanLinkCardProps, ScanMode } from '../types/scan';
 import { RepositoryScanForm } from './RepositoryScanForm';
 import { SingleScanForm } from './SingleScanForm';
-import { scanPageStyle } from './styles';
+import { getScanPageStyle } from './styles';
 
 export const ScanLinksCard = ({
   scanType,
@@ -19,6 +19,7 @@ export const ScanLinksCard = ({
 }: ScanLinkCardProps) => {
   const { t } = useTranslation();
   const isDark = useIsDark();
+  const scanPageStyle = getScanPageStyle(isDark);
 
   const isSingleTabActive = scanType === ScanMode.SINGLE;
 
@@ -35,7 +36,7 @@ export const ScanLinksCard = ({
     <Card withBorder shadow='0' style={scanPageStyle.scanCardStyle}>
       <header style={scanPageStyle.cardHeader}>
         <IconSearch style={scanPageStyle.searchIcon} />
-        <Typography style={scanPageStyle.cardTitle(isDark)}>
+        <Typography style={scanPageStyle.cardTitle}>
           {t('scanner_page.scan_links_card.title')}
         </Typography>
       </header>

--- a/src/pages/Scanner/components/ScanResultsCard.tsx
+++ b/src/pages/Scanner/components/ScanResultsCard.tsx
@@ -3,17 +3,18 @@ import { useTranslation } from 'react-i18next';
 import { useIsDark } from '@/components/Hooks/useIsDark';
 import { Card } from '@/components/UI/Card/Card';
 import { Typography } from '@/components/UI/Typography/Typography';
-import { scanPageStyle } from './styles';
+import { getScanPageStyle } from './styles';
 
 export const ScanResultsCard = () => {
   const { t } = useTranslation();
   const isDark = useIsDark();
+  const scanPageStyle = getScanPageStyle(isDark);
 
   return (
     <Card withBorder style={scanPageStyle.scanCardStyle}>
       <div style={scanPageStyle.cardHeader}>
         <IconAlertCircle style={scanPageStyle.alertIcon} />
-        <Typography style={scanPageStyle.cardTitle(isDark)}>
+        <Typography style={scanPageStyle.cardTitle}>
           {t('scanner_page.scan_results_card.title')}
         </Typography>
       </div>

--- a/src/pages/Scanner/components/ScanTitle.tsx
+++ b/src/pages/Scanner/components/ScanTitle.tsx
@@ -1,18 +1,19 @@
 import { useTranslation } from 'react-i18next';
 import { useIsDark } from '@/components/Hooks/useIsDark';
 import { Typography } from '@/components/UI/Typography/Typography';
-import { scanPageStyle } from './styles';
+import { getScanPageStyle } from './styles';
 
 export const ScanTitlePage = () => {
   const { t } = useTranslation();
   const isDark = useIsDark();
+  const scanPageStyle = getScanPageStyle(isDark);
 
   return (
     <div style={scanPageStyle.centerGrid}>
       <Typography variant='title' style={scanPageStyle.titleStyle}>
         <span style={scanPageStyle.titleStyle}>{t('scanner_page.title')} </span>
       </Typography>
-      <Typography style={scanPageStyle.text(isDark)}>{t('scanner_page.description')}</Typography>
+      <Typography style={scanPageStyle.text}>{t('scanner_page.description')}</Typography>
     </div>
   );
 };

--- a/src/pages/Scanner/components/SingleScanForm.tsx
+++ b/src/pages/Scanner/components/SingleScanForm.tsx
@@ -1,7 +1,8 @@
 import { ChangeEvent, FormEvent } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useIsDark } from '@/components/Hooks/useIsDark';
 import { Button } from '@/components/UI/Button/Button';
-import { scanPageStyle } from './styles';
+import { getScanPageStyle } from './styles';
 
 interface SingleScanFormProps {
   url: string;
@@ -11,6 +12,8 @@ interface SingleScanFormProps {
 
 export const SingleScanForm = ({ url, setUrl, onSubmit }: SingleScanFormProps) => {
   const { t } = useTranslation();
+  const isDark = useIsDark();
+  const scanPageStyle = getScanPageStyle(isDark);
   const baseTranslationKey = 'scanner_page.scan_links_card.single';
 
   const handleSubmit = (e?: FormEvent<HTMLFormElement>) => {

--- a/src/pages/Scanner/components/styles.ts
+++ b/src/pages/Scanner/components/styles.ts
@@ -14,19 +14,19 @@ const flexColumnCenter: CSSProperties = {
   justifyContent: 'center',
 };
 
-const baseInputStyle: CSSProperties = {
+const getBaseInputStyle = (isDark: boolean): CSSProperties => ({
   width: '100%',
   boxSizing: 'border-box',
   fontSize: theme.fontSizes.md,
-  color: colors.gray[5],
-  backgroundColor: colors.primary[7],
+  color: isDark ? colors.gray[5] : colors.gray[7],
+  backgroundColor: isDark ? colors.primary[7] : theme.white,
   padding: `${theme.spacing.md} ${theme.spacing.lg}`,
   borderRadius: theme.radius.md,
-  border: `1px solid ${colors.primary[5]}`,
+  border: `1px solid ${isDark ? colors.primary[5] : colors.gray[4]}`,
   outline: 'none',
-};
+});
 
-export const scanPageStyle = {
+export const getScanPageStyle = (isDark: boolean) => ({
   container: {
     ...flexColumnCenter,
     padding: '6rem 1.5rem',
@@ -51,11 +51,11 @@ export const scanPageStyle = {
     display: 'inline-block',
   },
 
-  text: (isDark: boolean): CSSProperties => ({
+  text: {
     color: getTextColor(isDark),
     paddingBlock: theme.spacing.lg,
     fontSize: '1.2em',
-  }),
+  } satisfies CSSProperties,
 
   scanCardsContainer: {
     display: 'grid',
@@ -76,10 +76,12 @@ export const scanPageStyle = {
     flexDirection: 'column',
     gap: theme.spacing.md,
     width: '100%',
-    backgroundColor: colors.primary[6],
-    borderColor: colors.primary[5],
+    backgroundColor: isDark ? colors.primary[6] : theme.white,
+    borderColor: isDark ? colors.primary[5] : colors.gray[3],
+    borderWidth: 1,
+    borderStyle: 'solid',
     borderRadius: theme.radius.lg,
-    boxShadow: 'none',
+    boxShadow: isDark ? 'none' : '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
   } satisfies CSSProperties,
 
   cardHeader: {
@@ -95,34 +97,34 @@ export const scanPageStyle = {
     marginBottom: theme.spacing.sm,
   } satisfies CSSProperties,
 
-  cardTitle: (isDark: boolean): CSSProperties => ({
+  cardTitle: {
     color: getTextColor(isDark),
     fontSize: theme.fontSizes['2xl'],
     fontWeight: 'bold',
     paddingBlock: theme.spacing.sm,
-  }),
+  } satisfies CSSProperties,
 
   segmentedControl: {
     borderRadius: theme.radius.md,
     root: {
-      backgroundColor: colors.primary[7],
+      backgroundColor: isDark ? colors.primary[7] : colors.gray[1],
     },
     label: {
-      color: colors.gray[4],
+      color: isDark ? colors.gray[4] : colors.gray[7],
     },
     indicator: {
-      backgroundColor: colors.primary[5],
+      backgroundColor: isDark ? colors.primary[5] : theme.white,
     },
   },
 
   textInput: {
     input: {
       fontSize: theme.fontSizes.md,
-      backgroundColor: colors.primary[7],
-      borderColor: colors.primary[5],
-      color: colors.gray[0],
+      backgroundColor: isDark ? colors.primary[7] : theme.white,
+      borderColor: isDark ? colors.primary[5] : colors.gray[4],
+      color: isDark ? colors.gray[0] : colors.gray[9],
       '&::placeholder': {
-        color: colors.gray[4],
+        color: isDark ? colors.gray[4] : colors.gray[5],
       },
     },
   },
@@ -138,7 +140,7 @@ export const scanPageStyle = {
   } satisfies CSSProperties,
 
   fieldLabel: {
-    color: colors.gray[0],
+    color: isDark ? colors.gray[0] : colors.gray[9],
     fontSize: theme.fontSizes.sm,
     width: '500px',
   } satisfies CSSProperties,
@@ -176,7 +178,7 @@ export const scanPageStyle = {
     width: '80px',
     height: '80px',
     opacity: 0.2,
-    color: 'white',
+    color: isDark ? 'white' : 'black',
   } satisfies CSSProperties,
 
   inputSection: {
@@ -194,27 +196,28 @@ export const scanPageStyle = {
   } satisfies CSSProperties,
 
   textInputStyle: {
-    ...baseInputStyle,
+    ...getBaseInputStyle(isDark),
   } satisfies CSSProperties,
 
   textareaStyle: {
-    ...baseInputStyle,
+    ...getBaseInputStyle(isDark),
     resize: 'vertical',
     minHeight: '100px',
   } satisfies CSSProperties,
 
   segmentedWrapper: {
     display: 'flex',
-    backgroundColor: colors.primary[7],
+    backgroundColor: isDark ? colors.primary[7] : colors.gray[1],
     padding: '4px',
     borderRadius: theme.radius.md,
   } satisfies CSSProperties,
 
   activeTab: {
     flex: 1,
-    backgroundColor: colors.primary[5],
-    color: 'white',
+    backgroundColor: isDark ? colors.primary[5] : theme.white,
+    color: isDark ? 'white' : colors.gray[9],
     border: 'none',
+    boxShadow: isDark ? 'none' : '0 1px 3px rgba(0,0,0,0.1)',
     borderRadius: theme.radius.sm,
     padding: '8px',
     cursor: 'pointer',
@@ -223,9 +226,9 @@ export const scanPageStyle = {
   passiveTab: {
     flex: 1,
     backgroundColor: 'transparent',
-    color: colors.gray[4],
+    color: isDark ? colors.gray[4] : colors.gray[6],
     border: 'none',
     padding: '8px',
     cursor: 'pointer',
   } satisfies CSSProperties,
-};
+});

--- a/src/pages/Statistics/components/Charts.tsx
+++ b/src/pages/Statistics/components/Charts.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { useMediaQuery } from '@mantine/hooks';
 import Chart from '@/components/Charts/Chart';
 import { ChartType, LineData } from '@/components/Charts/chart.types';
+import { useIsDark } from '@/components/Hooks/useIsDark';
 import { Card } from '@/components/UI/Card/Card';
 import { Typography } from '@/components/UI/Typography/Typography';
 import { theme } from '@/theme';
@@ -29,16 +30,17 @@ const lineData = {
 
 export default function Charts() {
   const { t } = useTranslation();
+  const isDark = useIsDark();
   const isMobileView = useMediaQuery(`(max-width: ${theme.breakpoints.lg})`);
   return (
     <div style={graphsStyles.containerDisplay(isMobileView)}>
       <Card style={graphsStyles.cardStyles(isMobileView)}>
-        <Typography style={graphsStyles.cardHeader}>{t('charts.scanActivity')}</Typography>
+        <Typography style={graphsStyles.cardHeader(isDark)}>{t('charts.scanActivity')}</Typography>
         <Chart type={ChartType.Line} data={lineData} />
       </Card>
 
       <Card style={graphsStyles.cardStyles(isMobileView)}>
-        <Typography style={graphsStyles.cardHeader}>
+        <Typography style={graphsStyles.cardHeader(isDark)}>
           {t('charts.linkTypesDistribustion')}
         </Typography>
         <Chart type={ChartType.Donut} data={donutData} />

--- a/src/pages/Statistics/components/styles.ts
+++ b/src/pages/Statistics/components/styles.ts
@@ -14,7 +14,12 @@ export const graphsStyles = {
     width: isMobileView ? '90%' : '30%',
     margin: theme.spacing.lg,
   }),
-  cardHeader: { color: theme.white, fontWeight: 'bold', fontSize: '1.4em', marginBottom: '1rem' },
+  cardHeader: (isDark: boolean): CSSProperties => ({
+    color: getTextColor(isDark),
+    fontWeight: 'bold',
+    fontSize: '1.4em',
+    marginBottom: '1rem',
+  }),
 };
 
 export const statisticsPageStyle = {


### PR DESCRIPTION
#345 
made several UI changes. There is an inconsistency of typography on different themes.

Hero Section:
<img width="1813" height="795" alt="image" src="https://github.com/user-attachments/assets/12d3ef54-8f83-49ef-9cd7-75328d630751" />

How it works cards:
<img width="1813" height="795" alt="image" src="https://github.com/user-attachments/assets/654af8ac-1f8b-41fa-8fc0-ad1d13dee108" />

Scanner Page:
<img width="1813" height="795" alt="image" src="https://github.com/user-attachments/assets/0a95e6a8-f843-41be-bd8e-00b8fc4771ec" />

About Cards:
<img width="1813" height="795" alt="image" src="https://github.com/user-attachments/assets/54994841-bcfa-4ee5-887b-9876c7329d3f" />

@Tamir198 can u once verify the UI?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dark mode support throughout the application with dynamic theme-aware styling for all major components, including charts, navigation, cards, and page layouts.

* **Refactor**
  * Improved theme system by converting static style objects to dynamic style functions that adapt styling based on the current theme preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->