### PR TITLE
fix: skip welcome comment on Dependabot PRs

### DIFF
--- a/.github/workflows/pr-welcome.yml
+++ b/.github/workflows/pr-welcome.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   comment:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Post welcome message
         uses: actions/github-script@v7


### PR DESCRIPTION
- Skip the welcome comment workflow when the PR is opened by Dependabot, avoiding unnecessary bot-on-bot interactions.

Close #363 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR welcome workflow to prevent notifications on automated dependency update pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->