### PR TITLE
fix: use empty string fallback when VITE_API_BASE_URL is not set

### DIFF
--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,1 +1,1 @@
-export const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+export const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';


### PR DESCRIPTION
## Summary

Fixes API request URL issue when `VITE_API_BASE_URL` is not configured.

## Changes

- Added `?? ` fallback in `src/constants/api.ts` so `BASE_URL` defaults to empty string instead of `undefined`
- This ensures relative API paths (e.g., `/api/check-url`) work correctly when no backend base URL is configured

## Testing

- Minimal change: 1 file, 1 line
- No behavioral change when `VITE_API_BASE_URL` is set
- When not set, requests now correctly use relative paths instead of sending to the frontend origin

Fixes #375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing API configuration by applying a fallback value to prevent potential runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->