### PR TITLE
docs: add discussions link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ We have a Discussions page where you can share ideas, ask questions, and connect
 [Discussions Page](https://github.com/Deadlink-Hunter/Broken-Link-Website/discussions)
 
 <p align="left"><a href="#top-btn">Go back to the top of the page</a></p>
+
 ## Environment Variables
 
 This project includes a `.env.example` file in the repository that lists the environment variables required to run the app.


### PR DESCRIPTION
## Description
Added a Discussions section to the README to help users share ideas, ask questions, and engage with the community. Also updated the link formatting to ensure proper navigation.

## Related Issue(s)
Fixes #382 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Discussions” section to the README with a new Table of Contents entry, descriptive text, a direct link to the project’s GitHub Discussions page, and a “Back to the top” link — providing a visible entry point for community conversations and support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->