### PR TITLE
Style(Navbar) - fixed disign for language select

### DIFF
--- a/src/components/Navbar/DesktopNav.tsx
+++ b/src/components/Navbar/DesktopNav.tsx
@@ -8,7 +8,7 @@ import { LinkButton, LinkTarget } from '../UI/Button/LinkButton';
 import { Link } from '../UI/Link/Link';
 import { Select } from '../UI/Select/Select';
 import NavbarLinks from './NavbarLinks';
-import { languageSelectStyles, desktopStyles as styles } from './styles';
+import { languageSelectProps, desktopStyles as styles } from './styles';
 import { ThemeToggle } from './ThemeToggle';
 
 export default function DesktopNav() {
@@ -41,12 +41,8 @@ export default function DesktopNav() {
           data={LANGUAGE_OPTIONS}
           value={currentLanguageLabel}
           onChange={handleLanguageChange}
-          allowDeselect={false}
-          styles={languageSelectStyles}
           leftSection={<IconWorld size={14} />}
-          leftSectionPointerEvents='none'
-          checkIconPosition='right'
-          maxDropdownHeight={200}
+          {...languageSelectProps}
         />
         <ThemeToggle />
       </div>

--- a/src/components/Navbar/MobileNav.tsx
+++ b/src/components/Navbar/MobileNav.tsx
@@ -9,7 +9,7 @@ import { Divider } from '../UI/Divider/Divider';
 import { Link } from '../UI/Link/Link';
 import { Select } from '../UI/Select/Select';
 import NavbarLinks from './NavbarLinks';
-import { languageSelectStyles, mobileStyles as styles } from './styles';
+import { languageSelectProps, mobileStyles as styles } from './styles';
 import { ThemeToggle } from './ThemeToggle';
 
 export default function MobileNav() {
@@ -43,12 +43,8 @@ export default function MobileNav() {
             data={LANGUAGE_OPTIONS}
             value={currentLanguageLabel}
             onChange={handleLanguageChange}
-            allowDeselect={false}
-            styles={languageSelectStyles}
             leftSection={<IconWorld size={14} />}
-            leftSectionPointerEvents='none'
-            checkIconPosition='right'
-            maxDropdownHeight={200}
+            {...languageSelectProps}
           />
           <ThemeToggle />
         </div>

--- a/src/components/Navbar/styles.ts
+++ b/src/components/Navbar/styles.ts
@@ -85,22 +85,27 @@ export const mobileStyles = {
   },
 };
 
-export const languageSelectStyles = {
-  root: {
-    width: '8rem',
-    maxWidth: '100%',
-  },
-  input: {
-    backgroundColor: theme.colors.primary[6],
-    color: theme.colors.primary[0],
-  },
-  section: {
-    color: theme.colors.primary[0],
-  },
-  dropdown: {
-    backgroundColor: theme.colors.primary[6],
-    borderColor: theme.colors.primary[5],
-    color: theme.colors.primary[0],
+export const languageSelectProps = {
+  allowDeselect: false,
+  leftSectionPointerEvents: 'none' as const,
+  checkIconPosition: 'right' as const,
+  maxDropdownHeight: 200,
+  styles: {
+    root: {
+      width: '8rem',
+    },
+    input: {
+      backgroundColor: theme.colors.primary[6],
+      color: theme.colors.primary[0],
+    },
+    section: {
+      color: theme.colors.primary[0],
+    },
+    dropdown: {
+      backgroundColor: theme.colors.primary[6],
+      borderColor: theme.colors.primary[5],
+      color: theme.colors.primary[0],
+    },
   },
 };
 


### PR DESCRIPTION
## Description

- Added dark background (primary[6]) 
- Added globe icon (IconWorld) as left section
- Checkmark positioned on the right via checkIconPosition='right'
- Extracted all styles into languageSelectStyles in Navbar/styles.ts to avoid inline styles

## Related Issue(s)
Fixes #394 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Language selector now shows a world icon in desktop and mobile for clearer identification.

* **Style**
  * Updated dropdown visuals with theme-aware colors and improved layout.
  * Constrained dropdown height for more consistent presentation.

* **Bug Fixes / Behavior**
  * Selection behavior refined to prevent accidental deselection and ensure consistent interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->