### PR TITLE
fix: scanner page cards not adapting to light mode

### DIFF
--- a/src/pages/Scanner/components/RepositoryScanForm.tsx
+++ b/src/pages/Scanner/components/RepositoryScanForm.tsx
@@ -10,6 +10,7 @@ interface RepositoryScanFormProps {
   multipleUrl: string;
   setMultipleUrl: (value: string) => void;
   onSubmit: () => void;
+  isDark: boolean;
 }
 
 export const RepositoryScanForm = ({
@@ -18,6 +19,7 @@ export const RepositoryScanForm = ({
   multipleUrl,
   setMultipleUrl,
   onSubmit,
+  isDark,
 }: RepositoryScanFormProps) => {
   const { t } = useTranslation();
   const baseTranslationKey = 'scanner_page.scan_links_card.repository';
@@ -38,7 +40,7 @@ export const RepositoryScanForm = ({
   return (
     <form onSubmit={handleSubmit}>
       <div style={scanPageStyle.formFieldGroup}>
-        <label htmlFor='repository-url' style={scanPageStyle.fieldLabel}>
+        <label htmlFor='repository-url' style={scanPageStyle.fieldLabel(isDark)}>
           {t(`${baseTranslationKey}.input_label`)}
         </label>
         <input
@@ -47,12 +49,12 @@ export const RepositoryScanForm = ({
           value={url}
           onChange={handleUrlChange}
           placeholder={t(`${baseTranslationKey}.input_placeholder`)}
-          style={scanPageStyle.textInputStyle}
+          style={scanPageStyle.textInputStyle(isDark)}
         />
       </div>
 
       <div style={scanPageStyle.formFieldGroup}>
-        <label htmlFor='multiple-urls' style={scanPageStyle.fieldLabel}>
+        <label htmlFor='multiple-urls' style={scanPageStyle.fieldLabel(isDark)}>
           {t(`${baseTranslationKey}.textarea_label`)}
         </label>
         {/* TODO - replace this with future shared text component */}
@@ -61,7 +63,7 @@ export const RepositoryScanForm = ({
           value={multipleUrl}
           onChange={handleMultipleUrlChange}
           placeholder={t(`${baseTranslationKey}.textarea_placeholder`)}
-          style={scanPageStyle.textareaStyle}
+          style={scanPageStyle.textareaStyle(isDark)}
           rows={4}
         />
       </div>

--- a/src/pages/Scanner/components/ScanLinksCard.tsx
+++ b/src/pages/Scanner/components/ScanLinksCard.tsx
@@ -23,10 +23,12 @@ export const ScanLinksCard = ({
 
   const isSingleTabActive = scanType === ScanMode.SINGLE;
 
-  const singleButtonStyle = isSingleTabActive ? scanPageStyle.activeTab : scanPageStyle.passiveTab;
+  const singleButtonStyle = isSingleTabActive
+    ? scanPageStyle.activeTab(isDark)
+    : scanPageStyle.passiveTab(isDark);
   const repositoryButtonStyle = isSingleTabActive
-    ? scanPageStyle.passiveTab
-    : scanPageStyle.activeTab;
+    ? scanPageStyle.passiveTab(isDark)
+    : scanPageStyle.activeTab(isDark);
 
   const submitScanRequest = () => {
     onScan({ scanType, url, multipleUrl });
@@ -36,13 +38,13 @@ export const ScanLinksCard = ({
     <Card withBorder shadow='0' style={scanPageStyle.scanCardStyle}>
       <header style={scanPageStyle.cardHeader}>
         <IconSearch style={scanPageStyle.searchIcon} />
-        <Typography style={scanPageStyle.cardTitle(isDark)}>
+        <Typography style={scanPageStyle.cardTitle}>
           {t('scanner_page.scan_links_card.title')}
         </Typography>
       </header>
 
       <div style={scanPageStyle.inputSection}>
-        <div style={scanPageStyle.segmentedWrapper}>
+        <div style={scanPageStyle.segmentedWrapper(isDark)}>
           <Button onClick={() => setScanType(ScanMode.SINGLE)} style={singleButtonStyle}>
             {t('scanner_page.scan_links_card.toggle.single')}
           </Button>
@@ -52,7 +54,7 @@ export const ScanLinksCard = ({
         </div>
 
         {isSingleTabActive ? (
-          <SingleScanForm url={url} setUrl={setUrl} onSubmit={submitScanRequest} />
+          <SingleScanForm url={url} setUrl={setUrl} onSubmit={submitScanRequest} isDark={isDark} />
         ) : (
           <RepositoryScanForm
             url={url}
@@ -60,6 +62,7 @@ export const ScanLinksCard = ({
             multipleUrl={multipleUrl}
             setMultipleUrl={setMultipleUrl}
             onSubmit={submitScanRequest}
+            isDark={isDark}
           />
         )}
       </div>

--- a/src/pages/Scanner/components/ScanResultsCard/CardShell.tsx
+++ b/src/pages/Scanner/components/ScanResultsCard/CardShell.tsx
@@ -1,7 +1,6 @@
 import type { CSSProperties, ReactNode } from 'react';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
-import { useIsDark } from '@/components/Hooks/useIsDark';
 import { Card } from '@/components/UI/Card/Card';
 import { Typography } from '@/components/UI/Typography/Typography';
 import { scanPageStyle } from '../styles';
@@ -14,13 +13,12 @@ interface CardShellProps {
 
 export const CardShell = ({ title, contentStyle, children }: CardShellProps) => {
   const { t } = useTranslation();
-  const isDark = useIsDark();
 
   return (
     <Card withBorder style={scanPageStyle.scanCardStyle}>
       <div style={scanPageStyle.cardHeader}>
         <IconAlertCircle style={scanPageStyle.alertIcon} />
-        <Typography style={scanPageStyle.cardTitle(isDark)}>{t(title)}</Typography>
+        <Typography style={scanPageStyle.cardTitle}>{t(title)}</Typography>
       </div>
       <div style={contentStyle}>{children}</div>
     </Card>

--- a/src/pages/Scanner/components/ScanResultsCard/EmptyState.tsx
+++ b/src/pages/Scanner/components/ScanResultsCard/EmptyState.tsx
@@ -6,12 +6,12 @@ import { CardShell } from './CardShell';
 
 const TITLE_KEY = 'scanner_page.scan_results_card.title';
 
-export const EmptyState = () => {
+export const EmptyState = ({ isDark }: { isDark: boolean }) => {
   const { t } = useTranslation();
 
   return (
     <CardShell title={TITLE_KEY} contentStyle={scanPageStyle.resultsStack}>
-      <IconSearch style={scanPageStyle.emptyStateIcon} />
+      <IconSearch style={scanPageStyle.emptyStateIcon(isDark)} />
       <Typography style={scanPageStyle.resultDescription}>
         {t('scanner_page.scan_results_card.empty_state')}
       </Typography>

--- a/src/pages/Scanner/components/ScanResultsCard/ScanResultsCard.tsx
+++ b/src/pages/Scanner/components/ScanResultsCard/ScanResultsCard.tsx
@@ -1,3 +1,4 @@
+import { useIsDark } from '@/components/Hooks/useIsDark';
 import {
   MultipleResultData,
   ResolvedKind,
@@ -12,6 +13,7 @@ import { MultipleResults } from './MultipleResults';
 import { SingleResult } from './SingleResult';
 
 export const ScanResultsCard = ({ results, loading, error }: ScanResultsCardProps) => {
+  const isDark = useIsDark();
   const resolved = resolveScanResults(results);
 
   if (loading) {
@@ -23,7 +25,7 @@ export const ScanResultsCard = ({ results, loading, error }: ScanResultsCardProp
   }
 
   if (!resolved) {
-    return <EmptyState />;
+    return <EmptyState isDark={isDark} />;
   }
 
   if (resolved.kind === ResolvedKind.SINGLE) {

--- a/src/pages/Scanner/components/SingleScanForm.tsx
+++ b/src/pages/Scanner/components/SingleScanForm.tsx
@@ -7,9 +7,10 @@ interface SingleScanFormProps {
   url: string;
   setUrl: (value: string) => void;
   onSubmit: () => void;
+  isDark: boolean;
 }
 
-export const SingleScanForm = ({ url, setUrl, onSubmit }: SingleScanFormProps) => {
+export const SingleScanForm = ({ url, setUrl, onSubmit, isDark }: SingleScanFormProps) => {
   const { t } = useTranslation();
   const baseTranslationKey = 'scanner_page.scan_links_card.single';
 
@@ -25,7 +26,7 @@ export const SingleScanForm = ({ url, setUrl, onSubmit }: SingleScanFormProps) =
   return (
     <form onSubmit={handleSubmit}>
       <div style={scanPageStyle.formFieldGroup}>
-        <label htmlFor='single-scan-url' style={scanPageStyle.fieldLabel}>
+        <label htmlFor='single-scan-url' style={scanPageStyle.fieldLabel(isDark)}>
           {t(`${baseTranslationKey}.input_label`)}
         </label>
         <input
@@ -34,7 +35,7 @@ export const SingleScanForm = ({ url, setUrl, onSubmit }: SingleScanFormProps) =
           placeholder={t(`${baseTranslationKey}.input_placeholder`)}
           value={url}
           onChange={handleUrlChange}
-          style={scanPageStyle.textInputStyle}
+          style={scanPageStyle.textInputStyle(isDark)}
         />
       </div>
 

--- a/src/pages/Scanner/components/styles.ts
+++ b/src/pages/Scanner/components/styles.ts
@@ -1,8 +1,9 @@
 import { CSSProperties } from 'react';
+import { rgba } from '@mantine/core';
 import { theme } from '@/theme';
 
 const colors = theme.colors;
-const getTextColor = (isDark: boolean) => (isDark ? theme.white : colors.gray[7]);
+const getTextColor = (isDark: boolean) => (isDark ? theme.white : theme.black);
 
 const flexColumnCenter: CSSProperties = {
   display: 'flex',
@@ -77,8 +78,8 @@ export const scanPageStyle = {
     flexDirection: 'column',
     gap: theme.spacing.md,
     width: '100%',
-    backgroundColor: colors.primary[6],
-    borderColor: colors.primary[5],
+    backgroundColor: rgba(colors.primary[6], 0.5),
+    border: `1px solid ${rgba(colors.primary[2], 0.15)}`,
     borderRadius: theme.radius.lg,
     boxShadow: 'none',
   } satisfies CSSProperties,
@@ -96,41 +97,16 @@ export const scanPageStyle = {
     marginBottom: theme.spacing.sm,
   } satisfies CSSProperties,
 
-  cardTitle: (isDark: boolean): CSSProperties => ({
-    color: getTextColor(isDark),
+  cardTitle: {
+    color: theme.white,
     fontSize: theme.fontSizes['2xl'],
     fontWeight: 'bold',
     paddingBlock: theme.spacing.sm,
-  }),
-
-  segmentedControl: {
-    borderRadius: theme.radius.md,
-    root: {
-      backgroundColor: colors.primary[7],
-    },
-    label: {
-      color: colors.gray[4],
-    },
-    indicator: {
-      backgroundColor: colors.primary[5],
-    },
-  },
-
-  textInput: {
-    input: {
-      fontSize: theme.fontSizes.md,
-      backgroundColor: colors.primary[7],
-      borderColor: colors.primary[5],
-      color: colors.gray[0],
-      '&::placeholder': {
-        color: colors.gray[4],
-      },
-    },
-  },
+  } satisfies CSSProperties,
 
   scanSubmitButtonIcon: {
     marginRight: '10px',
-  },
+  } satisfies CSSProperties,
 
   alertIcon: {
     width: '24px',
@@ -138,11 +114,11 @@ export const scanPageStyle = {
     color: colors.yellow[5],
   } satisfies CSSProperties,
 
-  fieldLabel: {
-    color: colors.gray[0],
+  fieldLabel: (isDark: boolean): CSSProperties => ({
+    color: isDark ? colors.gray[0] : rgba(theme.white, 0.72),
     fontSize: theme.fontSizes.sm,
     width: '500px',
-  } satisfies CSSProperties,
+  }),
 
   scanSubmitButton: {
     height: '50px',
@@ -158,7 +134,7 @@ export const scanPageStyle = {
   } satisfies CSSProperties,
 
   resultDescription: {
-    color: colors.gray[6],
+    color: rgba(theme.white, 0.72),
     maxWidth: '300px',
     width: '100%',
     textAlign: 'center',
@@ -173,12 +149,12 @@ export const scanPageStyle = {
     gap: theme.spacing.md,
   } satisfies CSSProperties,
 
-  emptyStateIcon: {
+  emptyStateIcon: (isDark: boolean): CSSProperties => ({
     width: '80px',
     height: '80px',
     opacity: 0.2,
-    color: 'white',
-  } satisfies CSSProperties,
+    color: getTextColor(isDark),
+  }),
 
   errorIcon: {
     width: '5rem',
@@ -202,11 +178,10 @@ export const scanPageStyle = {
     maxWidth: '100%',
   } satisfies CSSProperties,
 
-  statusIcon: (isBroken: boolean) =>
-    ({
-      color: isBroken ? colors.error[5] : colors.success[5],
-      flexShrink: 0,
-    }) satisfies CSSProperties,
+  statusIcon: (isBroken: boolean): CSSProperties => ({
+    color: isBroken ? colors.error[5] : colors.success[5],
+    flexShrink: 0,
+  }),
 
   resultsColumn: {
     display: 'flex',
@@ -236,39 +211,45 @@ export const scanPageStyle = {
     gap: theme.spacing.xs,
   } satisfies CSSProperties,
 
-  textInputStyle: {
+  textInputStyle: (isDark: boolean): CSSProperties => ({
     ...baseInputStyle,
-  } satisfies CSSProperties,
+    color: isDark ? colors.gray[0] : colors.gray[7],
+    backgroundColor: isDark ? colors.primary[7] : colors.primary[1],
+    border: `1px solid ${isDark ? colors.primary[5] : colors.primary[3]}`,
+  }),
 
-  textareaStyle: {
+  textareaStyle: (isDark: boolean): CSSProperties => ({
     ...baseInputStyle,
     resize: 'vertical',
     minHeight: '100px',
-  } satisfies CSSProperties,
+    color: isDark ? colors.gray[0] : colors.gray[7],
+    backgroundColor: isDark ? colors.primary[7] : colors.primary[1],
+    border: `1px solid ${isDark ? colors.primary[5] : colors.primary[3]}`,
+  }),
 
-  segmentedWrapper: {
+  segmentedWrapper: (isDark: boolean): CSSProperties => ({
     display: 'flex',
-    backgroundColor: colors.primary[7],
+    backgroundColor: isDark ? colors.primary[7] : colors.primary[1],
     padding: '4px',
     borderRadius: theme.radius.md,
-  } satisfies CSSProperties,
+  }),
 
-  activeTab: {
+  activeTab: (isDark: boolean): CSSProperties => ({
     flex: 1,
-    backgroundColor: colors.primary[5],
-    color: 'white',
+    backgroundColor: isDark ? colors.primary[5] : colors.primary[2],
+    color: isDark ? colors.gray[0] : colors.gray[8],
     border: 'none',
     borderRadius: theme.radius.sm,
     padding: '8px',
     cursor: 'pointer',
-  } satisfies CSSProperties,
+  }),
 
-  passiveTab: {
+  passiveTab: (isDark: boolean): CSSProperties => ({
     flex: 1,
     backgroundColor: 'transparent',
-    color: colors.gray[4],
+    color: isDark ? colors.gray[4] : colors.gray[6],
     border: 'none',
     padding: '8px',
     cursor: 'pointer',
-  } satisfies CSSProperties,
+  }),
 };


### PR DESCRIPTION
## Description
Scanner page cards were not adapting to light mode, they stayed dark regardless of the theme. The root cause was hardcoded styles in `styles.ts` that ignored `isDark`. Converted all affected styles to isDark-aware functions, fixed a crash on the Repository tab caused by a submit button style being called as a function, and removed unused dead styles.

## Related Issue(s)
Fixes #427

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if appropriate):
**before:**
<img width="2815" height="1525" alt="Screenshot 2026-04-11 220624" src="https://github.com/user-attachments/assets/f3af9b9e-0557-4cda-b298-565e764f9478" />
**after:**
<img width="2794" height="1508" alt="image" src="https://github.com/user-attachments/assets/47e0dda2-d342-48f4-9814-c69c0ba43165" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Enhanced dark mode theming throughout the scanner interface with improved visual styling and consistency across forms, buttons, tabs, and results display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->