### PR TITLE
docs: sync readme translations and remove login info (fixes #317)

### DIFF
--- a/readmes/README-PT-BR.md
+++ b/readmes/README-PT-BR.md
@@ -28,10 +28,6 @@ Este é o design geral desejado para o site, gerado pelo Lovable, apenas para se
 
 Você pode conferir a [interface mais elaborada](https://link-guard-191fc128.base44.app) que foi criada com base44 como inspiração inicial.
 
-<img width="434" height="667" alt="image" src="https://github.com/user-attachments/assets/6ae53712-a40a-4e33-bbb5-fd6445c3aec2" />
-
-Para ver a interface, faça login.
-
 <p align="left"><a href="#top-btn">Voltar ao topo da página</a></p>
 
 -----

--- a/readmes/README-TR.md
+++ b/readmes/README-TR.md
@@ -33,10 +33,6 @@ Dağıtıma çıkmış websitesini burdan görebilirsiniz: [Deadlink-Hunter Webs
 
 Kontrol edebilirsiniz [more elaborated ui](https://link-guard-191fc128.base44.app) ilk ilham kaynağı olarak base44 ile oluşturuldu.
 
-<img width="434" height="667" alt="image" src="https://github.com/user-attachments/assets/6ae53712-a40a-4e33-bbb5-fd6445c3aec2" />
-
-UI'ı görmek için giriş yapın.
-
 <p align="left"><a href="#top-btn">Sayfanın başına dön</a></p>
 
 ---

--- a/readmes/README-ZH-CN.md
+++ b/readmes/README-ZH-CN.md
@@ -18,10 +18,6 @@ Deadlink Hunter Website 是该网站的前端部分。
 
 您可以查看使用 base44 创建的[更精细的界面](https://link-guard-191fc128.base44.app)作为初始灵感来源。
 
-<img width="434" height="667" alt="image" src="https://github.com/user-attachments/assets/6ae53712-a40a-4e33-bbb5-fd6445c3aec2" />
-
-要查看界面请先登录。
-
 ## 目录
 - [为什么做这个项目](#为什么做这个项目)
 - [如何贡献](#如何贡献)


### PR DESCRIPTION
## Description
This PR synchronizes the translated README files with recent changes made to the main README. 

### Changes:
- Updated the "more elaborated UI" link to the new **base44** app (which no longer requires authentication).
- Removed outdated instructions and images regarding the login/sign-in process.
- Applied these changes to the following files:
  - `README-ZH-CN.md` (Chinese)
  - `README-TR.md` (Turkish)
  - `README-PT-BR.md` (Portuguese)

## Related Issue
Fixes #317

## Motivation and Context
The app interface has moved to a public-access model on base44. Keeping the old login instructions in the translated files was causing confusion for non-English speaking contributors.

## How Has This Been Tested?
- Verified that all updated links point to the correct base44 deployment.
- Checked the Markdown rendering to ensure no broken image tags or formatting issues remain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed screenshot images and associated login instructions from README files across multiple language versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->