### PR TITLE
chore: remove server notice from Scanner page and json files (#463)

### DIFF
--- a/src/locals/en.json
+++ b/src/locals/en.json
@@ -182,8 +182,7 @@
         "one_url_required": "At least one URL is required",
         "maximum_urls_allowed": "Maximum {{max}} URLs allowed per request"
       }
-    },
-    "server_notice": "*Right now we don't have a deployed server, the above will not work"
+    }
   },
   "error_boundary": {
     "title": "Something went wrong!",

--- a/src/locals/he.json
+++ b/src/locals/he.json
@@ -164,8 +164,7 @@
         "one_url_required": "נדרש לפחות URL אחד",
         "maximum_urls_allowed": "מקסימום {{max}} כתובות URL מותרות לכל בקשה"
       }
-    },
-    "server_notice": "*כרגע אין לנו שרת פעיל, ולכן מה שמופיע למעלה לא יעבוד"
+    }
   },
   "error_boundary": {
     "title": "משהו השתבש!",

--- a/src/pages/Scanner/Scanner.page.tsx
+++ b/src/pages/Scanner/Scanner.page.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import { useTranslation } from 'react-i18next';
 import { useMediaQuery } from '@mantine/hooks';
-import { Typography } from '@/components/UI/Typography/Typography';
 import { ApiErrorTypes } from '@/services/LinkChecker/types';
 import { theme } from '@/theme';
 import { ScanLinksCard } from './components/ScanLinksCard';
@@ -13,7 +11,6 @@ import { ScanMode, type ScanMutationVariables, type ScanResult } from './types/s
 import { runScan } from './utils/scanMutation';
 
 const ScannerPage = () => {
-  const { t } = useTranslation();
   const [scanType, setScanType] = useState<ScanMode>(ScanMode.SINGLE);
   const [url, setUrl] = useState('');
   const [multipleUrl, setMultipleUrl] = useState('');
@@ -54,8 +51,6 @@ const ScannerPage = () => {
           onScan={handleScan}
         />
         <ScanResultsCard results={data ?? null} loading={isPending} error={error ?? null} />
-        {/* TODO - Remove this when we have a deployed server */}
-        <Typography variant='title'>{t('scanner_page.server_notice')}</Typography>
       </section>
     </main>
   );


### PR DESCRIPTION
## Description
- Removed server notice, TODO and related unused variables, imports from `Scanner.page.tsx`
- Removed `server_notice` from `en.json` and `he.json`. Now not present elsewhere in the codebase.
## Related Issue(s)
Fixes #463 

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the server notice message from the scanner page that previously informed users about server unavailability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->