### PR TITLE
feat: add shared modal component

### DIFF
--- a/src/components/UI/Modal/Modal.test.tsx
+++ b/src/components/UI/Modal/Modal.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@test-utils';
+import { describe, expect, it } from 'vitest';
+import { Modal } from './Modal';
+
+describe('Modal', () => {
+  it('lets contentStyle override styles.content for overlapping content styles', () => {
+    render(
+      <Modal
+        opened
+        onClose={() => {}}
+        title='Styled modal'
+        fullScreen={false}
+        styles={{
+          content: {
+            backgroundColor: '#ff0000',
+            color: '#00ff00',
+          },
+        }}
+        contentStyle={{
+          backgroundColor: '#0000ff',
+        }}
+      >
+        Modal body
+      </Modal>
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Styled modal' });
+
+    expect(dialog).toHaveStyle({
+      backgroundColor: 'rgb(0, 0, 255)',
+      color: 'rgb(0, 255, 0)',
+    });
+  });
+});

--- a/src/components/UI/Modal/Modal.test.tsx
+++ b/src/components/UI/Modal/Modal.test.tsx
@@ -1,9 +1,14 @@
 import { render, screen } from '@test-utils';
 import { describe, expect, it } from 'vitest';
+import { theme } from '@/theme';
 import { Modal } from './Modal';
 
 describe('Modal', () => {
   it('lets contentStyle override styles.content for overlapping content styles', () => {
+    const slotBackgroundColor = theme.colors.error[5];
+    const slotTextColor = theme.colors.success[5];
+    const contentBackgroundColor = theme.colors.cyan[5];
+
     render(
       <Modal
         opened
@@ -12,12 +17,12 @@ describe('Modal', () => {
         fullScreen={false}
         styles={{
           content: {
-            backgroundColor: '#ff0000',
-            color: '#00ff00',
+            backgroundColor: slotBackgroundColor,
+            color: slotTextColor,
           },
         }}
         contentStyle={{
-          backgroundColor: '#0000ff',
+          backgroundColor: contentBackgroundColor,
         }}
       >
         Modal body
@@ -27,8 +32,8 @@ describe('Modal', () => {
     const dialog = screen.getByRole('dialog', { name: 'Styled modal' });
 
     expect(dialog).toHaveStyle({
-      backgroundColor: 'rgb(0, 0, 255)',
-      color: 'rgb(0, 255, 0)',
+      backgroundColor: contentBackgroundColor,
+      color: slotTextColor,
     });
   });
 });

--- a/src/components/UI/Modal/Modal.tsx
+++ b/src/components/UI/Modal/Modal.tsx
@@ -1,0 +1,34 @@
+import { CSSProperties } from 'react';
+import { Modal as MantineModal, ModalProps } from '@mantine/core';
+import { useMediaQuery } from '@mantine/hooks';
+import { useIsDark } from '@/components/Hooks/useIsDark';
+import { getModalContentStyles } from './styles';
+
+interface SharedModalProps extends ModalProps {
+  contentStyle?: CSSProperties;
+}
+
+export const Modal = ({
+  contentStyle = {},
+  fullScreen,
+  size = 'lg',
+  styles,
+  ...props
+}: SharedModalProps) => {
+  const isMobile = useMediaQuery('(max-width: 48em)');
+  const resolvedFullScreen = fullScreen ?? isMobile;
+  const isDark = useIsDark();
+  const baseContentStyles = getModalContentStyles(isDark);
+  const resolvedStyles: ModalProps['styles'] = {
+    ...styles,
+    content: {
+      ...baseContentStyles,
+      ...styles?.content,
+      ...contentStyle,
+    },
+  };
+
+  return (
+    <MantineModal {...props} fullScreen={resolvedFullScreen} size={size} styles={resolvedStyles} />
+  );
+};

--- a/src/components/UI/Modal/modal.story.tsx
+++ b/src/components/UI/Modal/modal.story.tsx
@@ -1,0 +1,187 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '../Button/Button';
+import { Modal } from './Modal';
+
+const storyContainerStyle = {
+  minHeight: '100vh',
+  display: 'grid',
+  placeItems: 'center',
+} satisfies React.CSSProperties;
+
+const actionRowStyle = {
+  display: 'flex',
+  gap: '1rem',
+  marginTop: '1rem',
+} satisfies React.CSSProperties;
+
+const meta: Meta<typeof Modal> = {
+  title: 'Components/UI/Modal',
+  component: Modal,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const ModalWithToggle = (props: Partial<React.ComponentProps<typeof Modal>>) => {
+  const [opened, setOpened] = useState(false);
+  return (
+    <div style={storyContainerStyle}>
+      <Button onClick={() => setOpened(true)}>Open Modal</Button>
+      <Modal opened={opened} onClose={() => setOpened(false)} {...props} />
+    </div>
+  );
+};
+
+export const TopAligned: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Shows Mantines default modal placement near the top of the viewport.',
+      },
+    },
+  },
+  render: () => (
+    <ModalWithToggle title='Top Aligned Modal' fullScreen={false}>
+      This example uses Mantine's default vertical placement near the top of the viewport.
+    </ModalWithToggle>
+  ),
+};
+
+export const Centered: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Uses the centered prop to vertically center the modal in the viewport.',
+      },
+    },
+  },
+  render: () => (
+    <ModalWithToggle title='Centered Modal' fullScreen={false} centered>
+      This example centers the modal vertically and horizontally.
+    </ModalWithToggle>
+  ),
+};
+
+export const OffsetFromTop: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Demonstrates how yOffset changes the modals distance from the top edge.',
+      },
+    },
+  },
+  render: () => (
+    <ModalWithToggle title='Offset Modal' fullScreen={false} yOffset='12vh'>
+      This example pushes the modal farther down from the top with a custom yOffset.
+    </ModalWithToggle>
+  ),
+};
+
+export const LargeSize: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Shows a larger modal width while keeping the dialog centered.',
+      },
+    },
+  },
+  render: () => (
+    <ModalWithToggle title='Large Modal' size='xl' fullScreen={false} centered>
+      This modal uses the large size variant.
+    </ModalWithToggle>
+  ),
+};
+
+export const ResponsiveDefault: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Keeps the wrapper default behavior, so the modal becomes full screen in narrow viewports.',
+      },
+    },
+  },
+  render: () => (
+    <ModalWithToggle title='Responsive Default Modal'>
+      This story keeps the wrapper default, so it becomes full screen in narrow viewports.
+    </ModalWithToggle>
+  ),
+};
+
+export const ForceFullScreen: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Forces full-screen mode regardless of viewport width.',
+      },
+    },
+  },
+  render: () => (
+    <ModalWithToggle title='Full Screen Modal' fullScreen>
+      This modal is full screen regardless of screen size.
+    </ModalWithToggle>
+  ),
+};
+
+export const WithCustomStyle: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Applies custom content styling through the wrappers contentStyle prop.',
+      },
+    },
+  },
+  render: () => (
+    <ModalWithToggle
+      title='Styled Content Modal'
+      fullScreen={false}
+      centered
+      contentStyle={{ backgroundColor: '#21213a', border: '2px solid #06b6d4', color: '#f8fafc' }}
+    >
+      This example styles the modal content surface with the wrapper's contentStyle prop.
+    </ModalWithToggle>
+  ),
+};
+
+export const WithActions: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Shows a realistic confirmation dialog layout with action buttons.',
+      },
+    },
+  },
+  render: () => {
+    const ModalWithActions = () => {
+      const [opened, setOpened] = useState(false);
+      return (
+        <div style={storyContainerStyle}>
+          <Button onClick={() => setOpened(true)}>Open Modal</Button>
+          <Modal
+            opened={opened}
+            onClose={() => setOpened(false)}
+            title='Confirm Action'
+            fullScreen={false}
+            centered
+          >
+            <p>Are you sure you want to proceed?</p>
+            <div style={actionRowStyle}>
+              <Button variant='error' onClick={() => setOpened(false)}>
+                Cancel
+              </Button>
+              <Button variant='success' onClick={() => setOpened(false)}>
+                Confirm
+              </Button>
+            </div>
+          </Modal>
+        </div>
+      );
+    };
+    return <ModalWithActions />;
+  },
+};

--- a/src/components/UI/Modal/styles.ts
+++ b/src/components/UI/Modal/styles.ts
@@ -1,4 +1,3 @@
-// src/components/UI/Modal/styles.ts
 import type { CSSProperties } from 'react';
 import { rgba } from '@mantine/core';
 import { theme } from '@/theme';

--- a/src/components/UI/Modal/styles.ts
+++ b/src/components/UI/Modal/styles.ts
@@ -1,0 +1,13 @@
+// src/components/UI/Modal/styles.ts
+import type { CSSProperties } from 'react';
+import { rgba } from '@mantine/core';
+import { theme } from '@/theme';
+
+const colors = theme.colors;
+
+export const getModalContentStyles = (isDark: boolean): CSSProperties => ({
+  border: `1px solid ${rgba(colors.primary[2], 0.15)}`,
+  borderRadius: theme.defaultRadius,
+  backgroundColor: isDark ? colors.primary[7] : theme.white,
+  color: isDark ? theme.white : colors.primary[7],
+});


### PR DESCRIPTION
## Description
Adds a shared Modal component based on Mantine Modal.

- responsive mobile fullscreen behavior with explicit override support
- default modal content styling extracted into [styles.ts](vscode-file://vscode-app/c:/Users/alonp/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- default light/dark modal surface colors using the existing [useIsDark](vscode-file://vscode-app/c:/Users/alonp/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) hook
- support for simple overrides via [contentStyle](vscode-file://vscode-app/c:/Users/alonp/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and advanced slot styling via Mantine [styles](vscode-file://vscode-app/c:/Users/alonp/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Storybook stories for common modal variants
- a focused test for style precedence

## Related Issue(s)
Fixes #73 

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if appropriate):

<img width="2824" height="1521" alt="Screenshot 2026-04-29 113837" src="https://github.com/user-attachments/assets/b7eef193-0ad7-45b5-97ae-473a76a332ab" />

<img width="2828" height="1510" alt="Screenshot 2026-04-29 113846" src="https://github.com/user-attachments/assets/c94ee3e0-7532-4346-a23d-7461620359f5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Modal component with responsive behavior (auto-fullscreen on narrow screens), theme-aware light/dark styling, and a prop to override content styles.

* **Tests**
  * Added unit tests validating style merging and precedence when multiple content style sources are provided.

* **Documentation**
  * Added Storybook stories demonstrating placement, sizing, fullscreen override, custom content styling, and action/confirmation variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->