### PR TITLE
fix: external links in footer should open in a new tab (#471)

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -61,7 +61,12 @@ export default function Footer() {
           <Box>
             <Typography style={footerStyles.header(isDark)}>{t('footer.Community')}</Typography>
             {footerCommunityLinks.map((link, i) => (
-              <Link key={i + link.label} href={link.href} label={link.label} />
+              <Link
+                key={i + link.label}
+                href={link.href}
+                label={link.label}
+                target={LinkTarget.Blank}
+              />
             ))}
           </Box>
         </SimpleGrid>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -60,10 +60,10 @@ export default function Footer() {
           <Box>
             <Typography style={footerStyles.header(isDark)}>{t('footer.Community')}</Typography>
             {footerCommunityLinks.map((link, i) => (
-              <Link 
-                key={i + link.label} 
-                href={link.href} 
-                label={link.label} 
+              <Link
+                key={i + link.label}
+                href={link.href}
+                label={link.label}
                 target={LinkTarget.Blank}
               />
             ))}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -22,7 +22,6 @@ export default function Footer() {
     <>
       <Divider />
       <Container style={footerStyles.container}>
-        {/* TODO: Replace mantine grid with styling from styles.ts or create a new grid component thats based on simple grid */}
         <SimpleGrid
           spacing={theme.spacing.xl}
           cols={footerStyles.topGridColLayout}
@@ -61,10 +60,10 @@ export default function Footer() {
           <Box>
             <Typography style={footerStyles.header(isDark)}>{t('footer.Community')}</Typography>
             {footerCommunityLinks.map((link, i) => (
-              <Link
-                key={i + link.label}
-                href={link.href}
-                label={link.label}
+              <Link 
+                key={i + link.label} 
+                href={link.href} 
+                label={link.label} 
                 target={LinkTarget.Blank}
               />
             ))}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -22,6 +22,7 @@ export default function Footer() {
     <>
       <Divider />
       <Container style={footerStyles.container}>
+        {/* TODO: Replace mantine grid with styling from styles.ts or create a new grid component thats based on simple grid */}
         <SimpleGrid
           spacing={theme.spacing.xl}
           cols={footerStyles.topGridColLayout}

--- a/src/components/UI/Link/Link.tsx
+++ b/src/components/UI/Link/Link.tsx
@@ -3,6 +3,7 @@ import { Link as RouterLink } from 'react-router-dom';
 import { NavLink } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { useIsDark } from '@/components/Hooks/useIsDark';
+import { LinkTarget } from '../Button/LinkButton';
 import { defaultHoverColor, linkStyles } from './styles';
 
 interface LinkProps {
@@ -13,6 +14,7 @@ interface LinkProps {
   disableHover?: boolean;
   hoverColor?: string;
   labelColor?: string;
+  target?: LinkTarget;
 }
 
 export const Link = ({
@@ -23,21 +25,40 @@ export const Link = ({
   disableHover = false,
   hoverColor = defaultHoverColor,
   labelColor,
+  target,
   ...props
 }: LinkProps) => {
   const { hovered, ref } = useHover();
   const isDark = useIsDark();
   const applyHover = disableHover ? false : hovered;
+
+  const sharedStyles = {
+    root: { ...linkStyles.root, ...rootStyle },
+    label: { ...linkStyles.label(applyHover, isDark, hoverColor, labelColor), ...labelStyle },
+  };
+
+  if (target === LinkTarget.Blank) {
+    return (
+      <NavLink
+        component="a"
+        ref={ref}
+        label={label}
+        href={href}
+        target={target}
+        rel="noopener noreferrer"
+        styles={sharedStyles}
+        {...props}
+      />
+    );
+  }
+
   return (
     <NavLink
       component={RouterLink}
       ref={ref}
       label={label}
       to={href}
-      styles={{
-        root: { ...linkStyles.root, ...rootStyle },
-        label: { ...linkStyles.label(applyHover, isDark, hoverColor, labelColor), ...labelStyle },
-      }}
+      styles={sharedStyles}
       {...props}
     />
   );

--- a/src/components/UI/Link/Link.tsx
+++ b/src/components/UI/Link/Link.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ComponentProps } from 'react';
+import { ComponentProps, CSSProperties } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { NavLink } from '@mantine/core';
 import { useHover } from '@mantine/hooks';

--- a/src/components/UI/Link/Link.tsx
+++ b/src/components/UI/Link/Link.tsx
@@ -14,7 +14,7 @@ interface LinkProps {
   disableHover?: boolean;
   hoverColor?: string;
   labelColor?: string;
-  target?: LinkTarget;
+  target?: LinkTarget | string;
 }
 
 export const Link = ({
@@ -32,33 +32,24 @@ export const Link = ({
   const isDark = useIsDark();
   const applyHover = disableHover ? false : hovered;
 
+  const isExternal = href.startsWith('http') || target === LinkTarget.Blank || target === '_blank';
+
   const sharedStyles = {
     root: { ...linkStyles.root, ...rootStyle },
     label: { ...linkStyles.label(applyHover, isDark, hoverColor, labelColor), ...labelStyle },
   };
 
-  if (target === LinkTarget.Blank) {
-    return (
-      <NavLink
-        component="a"
-        ref={ref}
-        label={label}
-        href={href}
-        target={target}
-        rel="noopener noreferrer"
-        styles={sharedStyles}
-        {...props}
-      />
-    );
-  }
-
   return (
     <NavLink
-      component={RouterLink}
       ref={ref}
       label={label}
-      to={href}
       styles={sharedStyles}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      component={(isExternal ? 'a' : RouterLink) as any}
+      href={isExternal ? href : undefined}
+      to={!isExternal ? href : undefined}
+      target={isExternal ? '_blank' : undefined}
+      rel={isExternal ? 'noopener noreferrer' : undefined}
       {...props}
     />
   );

--- a/src/components/UI/Link/Link.tsx
+++ b/src/components/UI/Link/Link.tsx
@@ -1,10 +1,22 @@
-import { CSSProperties } from 'react';
+import { CSSProperties, ComponentProps } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { NavLink } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { useIsDark } from '@/components/Hooks/useIsDark';
 import { LinkTarget } from '../Button/LinkButton';
 import { defaultHoverColor, linkStyles } from './styles';
+
+type DynamicNavLinkProps =
+  | {
+      component: 'a';
+      href: string;
+      target: '_blank';
+      rel: string;
+    }
+  | {
+      component: typeof RouterLink;
+      to: string;
+    };
 
 interface LinkProps {
   label: string;
@@ -38,8 +50,8 @@ export const Link = ({
     root: { ...linkStyles.root, ...rootStyle },
     label: { ...linkStyles.label(applyHover, isDark, hoverColor, labelColor), ...labelStyle },
   };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const linkProps: any = isExternal
+
+  const linkProps: DynamicNavLinkProps = isExternal
     ? {
         component: 'a',
         href,
@@ -56,7 +68,7 @@ export const Link = ({
       ref={ref}
       label={label}
       styles={sharedStyles}
-      {...linkProps}
+      {...(linkProps as ComponentProps<typeof NavLink>)}
       {...props}
     />
   );

--- a/src/components/UI/Link/Link.tsx
+++ b/src/components/UI/Link/Link.tsx
@@ -38,18 +38,25 @@ export const Link = ({
     root: { ...linkStyles.root, ...rootStyle },
     label: { ...linkStyles.label(applyHover, isDark, hoverColor, labelColor), ...labelStyle },
   };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const linkProps: any = isExternal
+    ? {
+        component: 'a',
+        href,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+      }
+    : {
+        component: RouterLink,
+        to: href,
+      };
 
   return (
     <NavLink
       ref={ref}
       label={label}
       styles={sharedStyles}
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      component={(isExternal ? 'a' : RouterLink) as any}
-      href={isExternal ? href : undefined}
-      to={!isExternal ? href : undefined}
-      target={isExternal ? '_blank' : undefined}
-      rel={isExternal ? 'noopener noreferrer' : undefined}
+      {...linkProps}
       {...props}
     />
   );


### PR DESCRIPTION
**Description:**

### Description
This PR addresses issue #471 by updating the footer links.

### Changes Made:
- **Link.tsx**: Updated the component to support the `target` prop and automatically add `rel="noopener noreferrer"` for security.
- **Footer.tsx**: Passed `LinkTarget.Blank` to all links in the Community section.

### Impact
- Internal links (About, Scanner, Stats) still open in the same tab.
- External links (GitHub-related) now open in a new tab, preventing users from losing their session.

Closes #471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Footer community links now open in a new browser tab/window to avoid interrupting your session.
  * Link handling improved to detect internal vs external destinations and open external links securely with appropriate safety attributes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Deadlink-Hunter/Broken-Link-Website/pull/472)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->