### PR TITLE
Use backend scanDuration for scan summary timing

### DIFF
--- a/src/pages/Scanner/components/ScanResultsCard/MultipleResults.tsx
+++ b/src/pages/Scanner/components/ScanResultsCard/MultipleResults.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from 'react-i18next';
 import type { MultipleResultData } from '@/pages/Scanner/types/scan';
-import { sumResponseTimes } from '@/pages/Scanner/utils/scan';
 import { msToSeconds } from '@/util/timeutils';
 import { scanPageStyle } from '../styles';
 import { CardShell } from './CardShell';
@@ -19,8 +18,8 @@ export const MultipleResults = ({
 }) => {
   const { t } = useTranslation();
   const { results: resultsList, summary } = data;
-  const { total, working, broken } = summary;
-  const timeInSeconds = msToSeconds(sumResponseTimes(resultsList));
+  const { total, working, broken, scanDuration } = summary;
+  const timeInSeconds = msToSeconds(scanDuration);
   const statusErrorText = t('scanner_page.scan_results_card.status_error');
 
   return (

--- a/src/pages/Scanner/components/ScanResultsCard/SummaryBar.tsx
+++ b/src/pages/Scanner/components/ScanResultsCard/SummaryBar.tsx
@@ -18,7 +18,7 @@ export const SummaryBar = ({ total, timeInSeconds, isDark }: SummaryBarProps) =>
       </div>
       <div>{DOT}</div>
       <div style={scanPageStyle.summaryTime(isDark)}>
-        {timeInSeconds} {t('scanner_page.scan_results_card.seconds')}
+        {timeInSeconds}{t('scanner_page.scan_results_card.seconds')}
       </div>
     </div>
   );

--- a/src/pages/Scanner/components/ScanResultsCard/SummaryBar.tsx
+++ b/src/pages/Scanner/components/ScanResultsCard/SummaryBar.tsx
@@ -18,7 +18,8 @@ export const SummaryBar = ({ total, timeInSeconds, isDark }: SummaryBarProps) =>
       </div>
       <div>{DOT}</div>
       <div style={scanPageStyle.summaryTime(isDark)}>
-        {timeInSeconds}{t('scanner_page.scan_results_card.seconds')}
+        {timeInSeconds}
+        {t('scanner_page.scan_results_card.seconds')}
       </div>
     </div>
   );

--- a/src/pages/Scanner/types/scan.ts
+++ b/src/pages/Scanner/types/scan.ts
@@ -21,6 +21,7 @@ export interface ScanSummary {
   total: number;
   broken: number;
   working: number;
+  scanDuration: number;
 }
 
 export interface SingleResultData extends UrlCheckData {

--- a/src/pages/Scanner/utils/scan.ts
+++ b/src/pages/Scanner/utils/scan.ts
@@ -1,8 +1,4 @@
-import type {
-  MultipleUrlsResponse,
-  UrlCheckData,
-  UrlCheckResult,
-} from '@/services/LinkChecker/types';
+import type { MultipleUrlsResponse, UrlCheckResult } from '@/services/LinkChecker/types';
 import { ResolvedKind, type ResolvedScanResults, type ScanResult } from '../types/scan';
 
 type BatchScanPayload = NonNullable<MultipleUrlsResponse['data']>;
@@ -47,8 +43,4 @@ export function resolveScanResults(result: ScanResult | null): ResolvedScanResul
     };
   }
   return null;
-}
-
-export function sumResponseTimes(items: UrlCheckData[]): number {
-  return items.reduce((sum, item) => sum + (item.responseTime ?? 0), 0);
 }

--- a/src/services/LinkChecker/types.ts
+++ b/src/services/LinkChecker/types.ts
@@ -31,7 +31,7 @@ export interface MultipleUrlsResponse {
   status: number;
   data?: {
     results: UrlCheckData[];
-    summary: { total: number; broken: number; working: number };
+    summary: { total: number; broken: number; working: number; scanDuration: number };
   };
   error?: ApiErrorTypes;
 }


### PR DESCRIPTION
Frontend follow-up for Deadlink-Hunter/Broken-Link-Checker#49
Depends on Deadlink-Hunter/Broken-Link-Checker#52

## What
Adds `scanDuration` to the frontend scan summary display, using the value now returned by the backend in `POST /api/check-urls`.

## Why
The frontend previously calculated scan time by summing the individual `responseTime` of each URL via a `sumResponseTimes` utility. However, since URLs are checked concurrently via `Promise.all`, this sum is misleading — scanning 10 URLs that each take 300ms would show 3000ms, when the actual elapsed time is ~300ms.

This PR consumes the `scanDuration` field introduced in the backend (Deadlink-Hunter/Broken-Link-Checker#52) and displays the accurate wall-clock duration instead.

## Changes

**`src/services/LinkChecker/types.ts`**
Added `scanDuration: number` to the `summary` type inside `MultipleUrlsResponse`, reflecting the updated API response shape.

**`src/pages/Scanner/types/scan.ts`**
Added `scanDuration: number` to the `ScanSummary` interface.

**`src/pages/Scanner/components/ScanResultsCard/MultipleResults.tsx`**
Updated to destructure `scanDuration` from the summary and convert it from milliseconds to seconds using the existing `msToSeconds()` utility before passing it to `SummaryBar`.

**`src/pages/Scanner/utils/scan.ts`**
Removed the `sumResponseTimes` helper, which is no longer used.

## Notes
* `scanDuration` is received in milliseconds from the backend. Conversion to seconds for display is handled by `msToSeconds()`.
* `responseTime` per individual URL is unaffected and remains in each result object.
* This PR depends on the backend PR being merged first. It was kept separate to maintain a clean separation between API and UI changes.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved scan duration tracking and calculation methodology for more accurate timing data
  * Updated scan time display formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->