### PR TITLE
refactor(footer): create shared UI Grid component and remove Mantine SimpleGrid

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,7 +1,7 @@
 import { IconCode, IconHeart, IconStar } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { Box, Container, SimpleGrid, Text } from '@mantine/core';
+import { Box, Container, Text } from '@mantine/core'; 
 import { useViewportSize } from '@mantine/hooks';
 import { useNavigationLinks } from '@/components/Hooks/useNavigationLinks';
 import { GITHUB_QUERY_KEY, GITHUB_STALE_TIME } from '@/constants/api.consts';
@@ -32,12 +32,8 @@ export default function Footer() {
     <>
       <Divider />
       <Container style={footerStyles.container}>
-        {/* TODO: Replace mantine grid with styling from styles.ts or create a new grid component thats based on simple grid */}
-        <SimpleGrid
-          spacing={theme.spacing.xl}
-          cols={footerStyles.topGridColLayout}
-          style={footerStyles.linkBoxWrapper}
-        >
+        {/* TODO Resolved: Replaced mantine grid with styling from styles.ts */}
+        <div style={footerStyles.topGrid(isMobileView)}>
           <Box>
             <Text
               inherit
@@ -79,13 +75,13 @@ export default function Footer() {
               />
             ))}
           </Box>
-        </SimpleGrid>
+        </div>
       </Container>
 
       <Divider />
 
       <Container style={footerStyles.container}>
-        <SimpleGrid style={footerStyles.bottomGrid} cols={footerStyles.bottomGridColLayout}>
+        <div style={footerStyles.bottomGrid(isMobileView)}>
           <Typography style={footerStyles.openSrcTxt(isMobileView, isDark)}>
             <IconCode size={footerStyles.iconSize} /> {t('footer.madeWith')}
             <IconHeart color={theme.colors.red[8]} size={footerStyles.iconSize} />
@@ -94,7 +90,7 @@ export default function Footer() {
           <Typography style={footerStyles.rightsTxt(isMobileView, isDark)}>
             {t('footer.rights')}
           </Typography>
-        </SimpleGrid>
+        </div>
       </Container>
     </>
   );

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -12,6 +12,7 @@ import { LinkButton, LinkTarget } from '../UI/Button/LinkButton';
 import { Divider } from '../UI/Divider/Divider';
 import { Link } from '../UI/Link/Link';
 import { Typography } from '../UI/Typography/Typography';
+import { Grid } from '../UI/Grid/Grid'; 
 import { footerStyles } from './styles';
 
 export default function Footer() {
@@ -32,8 +33,12 @@ export default function Footer() {
     <>
       <Divider />
       <Container style={footerStyles.container}>
-        {/* TODO Resolved: Replaced mantine grid with styling from styles.ts */}
-        <div style={footerStyles.topGrid(isMobileView)}>
+        <Grid
+          spacing={theme.spacing.xl}
+          cols={3}
+          mobileCols={1}
+          style={footerStyles.linkBoxWrapper}
+        >
           <Box>
             <Text
               inherit
@@ -75,13 +80,18 @@ export default function Footer() {
               />
             ))}
           </Box>
-        </div>
+        </Grid>
       </Container>
 
       <Divider />
 
       <Container style={footerStyles.container}>
-        <div style={footerStyles.bottomGrid(isMobileView)}>
+        <Grid
+          spacing={theme.spacing.xl}
+          cols={2}
+          mobileCols={1}
+          style={footerStyles.bottomGrid}
+        >
           <Typography style={footerStyles.openSrcTxt(isMobileView, isDark)}>
             <IconCode size={footerStyles.iconSize} /> {t('footer.madeWith')}
             <IconHeart color={theme.colors.red[8]} size={footerStyles.iconSize} />
@@ -90,7 +100,7 @@ export default function Footer() {
           <Typography style={footerStyles.rightsTxt(isMobileView, isDark)}>
             {t('footer.rights')}
           </Typography>
-        </div>
+        </Grid>
       </Container>
     </>
   );

--- a/src/components/Footer/styles.ts
+++ b/src/components/Footer/styles.ts
@@ -24,21 +24,9 @@ export const footerStyles = {
     color: isDark ? theme.white : theme.black,
   }),
 
-  topGrid: (isMobileView: boolean): CSSProperties => ({
-    display: 'grid',
-    gridTemplateColumns: isMobileView ? '1fr' : 'repeat(3, 1fr)',
-    gap: theme.spacing.xl,
+  linkBoxWrapper: {
     paddingBottom: '3rem',
-  }),
-
-  bottomGrid: (isMobileView: boolean): CSSProperties => ({
-    display: 'grid',
-    gridTemplateColumns: isMobileView ? '1fr' : 'repeat(2, 1fr)',
-    gap: theme.spacing.xl,
-    paddingTop: '1rem',
-    paddingBottom: '4rem',
-    alignItems: 'center',
-  }),
+  },
 
   openSrcTxt: (isMobileView: boolean, isDark: boolean): CSSProperties => ({
     display: 'flex',
@@ -61,4 +49,10 @@ export const footerStyles = {
   },
 
   iconSize: 16,
+  
+  bottomGrid: {
+    paddingTop: '1rem',
+    paddingBottom: '4rem',
+    alignItems: 'center',
+  },
 };

--- a/src/components/Footer/styles.ts
+++ b/src/components/Footer/styles.ts
@@ -24,9 +24,21 @@ export const footerStyles = {
     color: isDark ? theme.white : theme.black,
   }),
 
-  linkBoxWrapper: {
+  topGrid: (isMobileView: boolean): CSSProperties => ({
+    display: 'grid',
+    gridTemplateColumns: isMobileView ? '1fr' : 'repeat(3, 1fr)',
+    gap: theme.spacing.xl,
     paddingBottom: '3rem',
-  },
+  }),
+
+  bottomGrid: (isMobileView: boolean): CSSProperties => ({
+    display: 'grid',
+    gridTemplateColumns: isMobileView ? '1fr' : 'repeat(2, 1fr)',
+    gap: theme.spacing.xl,
+    paddingTop: '1rem',
+    paddingBottom: '4rem',
+    alignItems: 'center',
+  }),
 
   openSrcTxt: (isMobileView: boolean, isDark: boolean): CSSProperties => ({
     display: 'flex',
@@ -49,10 +61,4 @@ export const footerStyles = {
   },
 
   iconSize: 16,
-  topGridColLayout: { base: 1, sm: 1, md: 3 },
-  bottomGridColLayout: { base: 1, sm: 2 },
-  bottomGrid: {
-    paddingTop: '1rem',
-    paddingBottom: '4rem',
-  },
 };

--- a/src/components/UI/Grid/Grid.tsx
+++ b/src/components/UI/Grid/Grid.tsx
@@ -1,10 +1,11 @@
-import { CSSProperties, ReactNode } from 'react';
-import { useViewportSize } from '@mantine/hooks';
+import { ReactNode, CSSProperties } from 'react';
+import { useMediaQuery } from '@mantine/hooks';
+import { gridStyles } from './styles';
 
 interface GridProps {
   children: ReactNode;
-  cols?: number; 
-  mobileCols?: number; 
+  cols?: number;
+  mobileCols?: number;
   spacing?: string | number;
   style?: CSSProperties;
 }
@@ -16,15 +17,11 @@ export const Grid = ({
   spacing = '1rem',
   style,
 }: GridProps) => {
-  const { width } = useViewportSize();
-  const isMobileView = width < 1024;
+  const isMobileView = useMediaQuery('(max-width: 1024px)') || false;
 
-  const gridStyle: CSSProperties = {
-    display: 'grid',
-    gridTemplateColumns: `repeat(${isMobileView ? mobileCols : cols}, 1fr)`,
-    gap: spacing,
-    ...style,
-  };
-
-  return <div style={gridStyle}>{children}</div>;
+  return (
+    <div style={{ ...gridStyles.container(cols, mobileCols, isMobileView, spacing), ...style }}>
+      {children}
+    </div>
+  );
 };

--- a/src/components/UI/Grid/Grid.tsx
+++ b/src/components/UI/Grid/Grid.tsx
@@ -1,0 +1,30 @@
+import { CSSProperties, ReactNode } from 'react';
+import { useViewportSize } from '@mantine/hooks';
+
+interface GridProps {
+  children: ReactNode;
+  cols?: number; 
+  mobileCols?: number; 
+  spacing?: string | number;
+  style?: CSSProperties;
+}
+
+export const Grid = ({
+  children,
+  cols = 1,
+  mobileCols = 1,
+  spacing = '1rem',
+  style,
+}: GridProps) => {
+  const { width } = useViewportSize();
+  const isMobileView = width < 1024;
+
+  const gridStyle: CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: `repeat(${isMobileView ? mobileCols : cols}, 1fr)`,
+    gap: spacing,
+    ...style,
+  };
+
+  return <div style={gridStyle}>{children}</div>;
+};

--- a/src/components/UI/Grid/styles.ts
+++ b/src/components/UI/Grid/styles.ts
@@ -1,0 +1,9 @@
+import { CSSProperties } from 'react';
+
+export const gridStyles = {
+  container: (cols: number, mobileCols: number, isMobileView: boolean, spacing: string | number): CSSProperties => ({
+    display: 'grid',
+    gridTemplateColumns: `repeat(${isMobileView ? mobileCols : cols}, 1fr)`,
+    gap: spacing,
+  }),
+};


### PR DESCRIPTION
### Description
This PR addresses the technical debt TODO in the `Footer` component regarding the removal of Mantine's `<SimpleGrid>`. 

Following the feedback, instead of just isolating the grid styles to the footer, I have extracted the layout logic into a newly created, reusable `<Grid>` component inside the shared `src/components/UI` folder. This allows the custom grid to be easily utilized across the entire application while successfully decoupling the footer from the external UI library layout.

### Changes Made
- Created a new shared component: `src/components/UI/Grid/Grid.tsx` with responsive column and spacing logic.
- Refactored `Footer.tsx` to utilize the new custom `<Grid>` component instead of Mantine's `<SimpleGrid>`.
- Cleaned up `src/components/Footer/styles.ts` by removing deprecated library layout properties and isolating style logic.

Closes #489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a reusable Grid component for laying out content with configurable columns, mobile behavior and spacing.

* **UI/UX Improvements**
  * Footer layout updated to use the new grid system for more consistent structure and responsive behavior.
  * Bottom section vertically centered for improved alignment across viewports.

* **Style**
  * Footer spacing and alignment tweaks for cleaner presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Deadlink-Hunter/Broken-Link-Website/pull/490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->