### PR TITLE
UI: disable repository input field and add not supported message #497

### DIFF
--- a/src/locals/chin.json
+++ b/src/locals/chin.json
@@ -152,6 +152,7 @@
       "repository": {
         "input_label": "GitHub 儲存庫 URL",
         "input_placeholder": "https://github.com/username/repository",
+        "repository_not_supported": "目前不支援掃描完整的 GitHub 儲存庫。",
         "textarea_label": "或貼上多個URL。",
         "textarea_placeholder": "https://example1.com\nhttps://example2.com\nhttps://example3.com",
         "button_check": "掃描儲存庫"

--- a/src/locals/de.json
+++ b/src/locals/de.json
@@ -122,6 +122,7 @@
       "repository": {
         "input_label": "GitHub Repository URL",
         "input_placeholder": "https://github.com/nutzer/repo",
+        "repository_not_supported": "Das Scannen eines vollständigen GitHub-Repositories wird derzeit nicht unterstützt.",
         "textarea_label": "Oder mehrere URLs einfügen",
         "textarea_placeholder": "https://example1.com\nhttps://example2.com",
         "button_check": "Repository scannen"

--- a/src/locals/en.json
+++ b/src/locals/en.json
@@ -157,6 +157,7 @@
       "repository": {
         "input_label": "GitHub Repository URL",
         "input_placeholder": "https://github.com/username/repository",
+        "repository_not_supported": "Scanning a full GitHub repository is not supported right now.",
         "textarea_label": "Or paste multiple URLs",
         "textarea_placeholder": "https://example1.com\nhttps://example2.com\nhttps://example3.com",
         "button_check": "Scan Repository"

--- a/src/locals/es.json
+++ b/src/locals/es.json
@@ -139,6 +139,7 @@
       "repository": {
         "input_label": "URL del Repositorio de GitHub",
         "input_placeholder": "https://github.com/usuario/repositorio",
+        "repository_not_supported": "El escaneo de un repositorio completo de GitHub no está disponible en este momento.",
         "textarea_label": "O pegue varias URLs",
         "textarea_placeholder": "https://ejemplo1.com\nhttps://ejemplo2.com\nhttps://ejemplo3.com",
         "button_check": "Escanear Repositorio"

--- a/src/locals/fr.json
+++ b/src/locals/fr.json
@@ -139,6 +139,7 @@
       "repository": {
         "input_label": "URL du dépôt GitHub",
         "input_placeholder": "https://github.com/nom/depot",
+        "repository_not_supported": "L'analyse d'un dépôt GitHub complet n'est pas prise en charge pour le moment.",
         "textarea_label": "Ou collez plusieurs URLs",
         "textarea_placeholder": "https://exemple1.com\nhttps://exemple2.com",
         "button_check": "Analyser le dépôt"

--- a/src/locals/he.json
+++ b/src/locals/he.json
@@ -139,6 +139,7 @@
       "repository": {
         "input_label": "כתובת מאגר GitHub",
         "input_placeholder": "https://github.com/username/repository",
+        "repository_not_supported": "סריקת מאגר GitHub שלם אינה נתמכת כרגע.",
         "textarea_label": "או הדבק מספר כתובות URL",
         "textarea_placeholder": "https://example1.com\nhttps://example2.com\nhttps://example3.com",
         "button_check": "סרוק מאגר"

--- a/src/locals/it.json
+++ b/src/locals/it.json
@@ -142,6 +142,7 @@
       "repository": {
         "input_label": "URL del Repository GitHub",
         "input_placeholder": "https://github.com/user/repository",
+        "repository_not_supported": "La scansione di un intero repository GitHub non è supportata al momento.",
         "textarea_label": "Oppure incolla più URL",
         "textarea_placeholder": "https://example1.com\nhttps://example2.com\nhttps://example3.com",
         "button_check": "Scansiona Repository"

--- a/src/locals/nl.json
+++ b/src/locals/nl.json
@@ -139,6 +139,7 @@
       "repository": {
         "input_label": "GitHub Repository URL",
         "input_placeholder": "https://github.com/gebruikersnaam/repository",
+        "repository_not_supported": "Het scannen van een volledig GitHub-repository wordt momenteel niet ondersteund.",
         "textarea_label": "Of plak meerdere URL's",
         "textarea_placeholder": "https://example1.com\nhttps://example2.com",
         "button_check": "Scan repository"

--- a/src/locals/ptbr.json
+++ b/src/locals/ptbr.json
@@ -139,6 +139,7 @@
       "repository": {
         "input_label": "URL do Repositório GitHub",
         "input_placeholder": "https://github.com/usuario/repositorio",
+        "repository_not_supported": "A varredura de um repositório GitHub completo não é suportada no momento.",
         "textarea_label": "Ou cole várias URLs",
         "textarea_placeholder": "https://exemplo1.com\nhttps://exemplo2.com\nhttps://exemplo3.com",
         "button_check": "Escanear Repositório"

--- a/src/locals/tur.json
+++ b/src/locals/tur.json
@@ -139,6 +139,7 @@
       "repository": {
         "input_label": "GitHub Depo URL",
         "input_placeholder": "https://github.com/kullaniciadi/depo",
+        "repository_not_supported": "Tam bir GitHub deposunun taranması şu an desteklenmemektedir.",
         "textarea_label": "Ya da birden fazla URL yapıştırın",
         "textarea_placeholder": "https://example1.com\nhttps://example2.com\nhttps://example3.com",
         "button_check": "Depoyu Tara"

--- a/src/pages/Scanner/components/RepositoryScanForm.tsx
+++ b/src/pages/Scanner/components/RepositoryScanForm.tsx
@@ -50,7 +50,17 @@ export const RepositoryScanForm = ({
           onChange={handleUrlChange}
           placeholder={t(`${baseTranslationKey}.input_placeholder`)}
           style={scanPageStyle.textInputStyle(isDark)}
+          disabled
         />
+        <div
+          style={{
+            fontSize: '0.875rem',
+            color: isDark ? '#a6a6a6' : '#666',
+            marginTop: '0.5rem',
+          }}
+        >
+          {t(`${baseTranslationKey}.repository_not_supported`)}
+        </div>
       </div>
 
       <div style={scanPageStyle.formFieldGroup}>

--- a/src/pages/Scanner/components/RepositoryScanForm.tsx
+++ b/src/pages/Scanner/components/RepositoryScanForm.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, FormEvent } from 'react';
 import { IconUpload } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/UI/Button/Button';
+import { Typography } from '@/components/UI/Typography/Typography';
 import { scanPageStyle } from './styles';
 
 interface RepositoryScanFormProps {
@@ -52,15 +53,9 @@ export const RepositoryScanForm = ({
           style={scanPageStyle.textInputStyle(isDark)}
           disabled
         />
-        <div
-          style={{
-            fontSize: '0.875rem',
-            color: isDark ? '#a6a6a6' : '#666',
-            marginTop: '0.5rem',
-          }}
-        >
+        <Typography style={scanPageStyle.unsupportedMessage(isDark)}>
           {t(`${baseTranslationKey}.repository_not_supported`)}
-        </div>
+        </Typography>
       </div>
 
       <div style={scanPageStyle.formFieldGroup}>

--- a/src/pages/Scanner/components/styles.ts
+++ b/src/pages/Scanner/components/styles.ts
@@ -361,4 +361,10 @@ export const scanPageStyle = {
     color: isDark ? theme.white : colors.gray[8],
     fontWeight: 'bold',
   }),
+
+  unsupportedMessage: (isDark: boolean): CSSProperties => ({
+    fontSize: theme.fontSizes.sm,
+    color: isDark ? colors.gray[4] : colors.gray[6],
+    marginTop: theme.spacing.xs,
+  }),
 };


### PR DESCRIPTION
## Description
Disabled the repository input field and added a descriptive message stating that scanning full GitHub repositories is not currently supported, as requested by the maintainer.

## Related Issue(s)
Closes #497

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the scanner page to clearly inform users that scanning a full GitHub repository is not supported.
  * Disabled the repository URL input and added supportive helper text beneath it (with light/dark styling).
* **Localization**
  * Added the new `repository_not_supported` message to all supported languages so the UI displays the correct wording.
* **Style**
  * Added styling for the new “unsupported” helper message text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->