### PR TITLE
Moved agent rules to AGENTS.md, pointed .cursor/rules to this file, gave hint where to find the rules

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,10 +1,6 @@
 ---
-description: Cursor rules for maintaining clean and consistent codebase
+description: Shared agent rules, single source of truth is AGENTS.md
 alwaysApply: true
 ---
 
-- Remove all AI-generated comments.
-- Avoid mega-files: split files larger than 300–400 lines into logical components or utilities.
-- Never hardcode colors (e.g. `#2196F3`, `'red'`, `'white'`) — use them from the theme.
-- No hardcoded strings; use constants from the global constants folder.
-- If a component has a lot of logic, extract it into a utility or custom hook.
+Follow the rules in [AGENTS.md](../AGENTS.md). Do not duplicate rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Rules
+
+Single source of truth for all AI coding agents (Cursor, Copilot, Claude Code, etc.).
+
+- Remove all AI-generated comments.
+- Avoid mega-files: split files larger than 300–400 lines into logical components or utilities.
+- Never hardcode colors (e.g. `#2196F3`, `'red'`, `'white'`); use them from the theme.
+- No hardcoded strings; use constants from the global constants folder.
+- If a component has a lot of logic, extract it into a utility or custom hook.
+
+Also follow the style guidelines in [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 To maintain a consistent codebase, we ask that all contributors follow these stylistic guidelines.
 
+> Using an AI agent? Shared rules live in [AGENTS.md](./AGENTS.md). Tool-specific configs (like `.cursor/rules`) should only point there, never duplicate rules.
+
 ## 1. TypeScript First
 
 **No any:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,4 @@
-To maintain a consistent codebase, we ask that all contributors follow these stylistic guidelines.
-
-> Using an AI agent? Shared rules live in [AGENTS.md](./AGENTS.md). Tool-specific configs (like `.cursor/rules`) should only point there, never duplicate rules.
+To maintain a consistent codebase, we ask that all contributors follow these stylistic guidelines. 
 
 ## 1. TypeScript First
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Centralized AI-assisted development guidance into a shared reference and updated local AI tool rules to point to it.
  * Updated contributor documentation to align with the centralized guidance.
  * Minor formatting adjustment (added trailing whitespace) in the contributor guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->