### PR TITLE
Fix nav links color issue in light theme (#461)

### DIFF
--- a/src/components/Navbar/ThemeToggle.tsx
+++ b/src/components/Navbar/ThemeToggle.tsx
@@ -29,7 +29,11 @@ export function ThemeToggle() {
         }}
         variant='icon'
       >
-        {theme ? <IconMoon size={16} /> : <IconSun size={16} />}
+    {theme ? (
+  <IconMoon size={16} color="var(--mantine-color-text)" />
+) : (
+  <IconSun size={16} color="var(--mantine-color-text)" />
+)}
       </Button>
     </div>
   );

--- a/src/components/Navbar/ThemeToggle.tsx
+++ b/src/components/Navbar/ThemeToggle.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { IconMoon, IconSun } from '@tabler/icons-react';
 import { useComputedColorScheme, useMantineColorScheme } from '@mantine/core';
 import { Button } from '../UI/Button/Button';
+import { themeToggleStyles } from './styles';
 
 export function ThemeToggle() {
   const enum colorSchemes {
@@ -30,9 +31,9 @@ export function ThemeToggle() {
         variant='icon'
       >
     {theme ? (
-  <IconMoon size={16} color="var(--mantine-color-text)" />
+  <IconMoon size={16} style={themeToggleStyles} />
 ) : (
-  <IconSun size={16} color="var(--mantine-color-text)" />
+  <IconSun size={16} style={themeToggleStyles} />
 )}
       </Button>
     </div>

--- a/src/components/Navbar/styles.ts
+++ b/src/components/Navbar/styles.ts
@@ -95,6 +95,10 @@ export const mobileStyles = {
   },
 };
 
+export const themeToggleStyles = {
+  color: `light-dark(${theme.colors.primary[7]}, ${theme.colors.primary[0]})`,
+};
+
 export const languageSelectProps = {
   allowDeselect: false,
   variant: 'ghost' as const,
@@ -108,12 +112,12 @@ export const languageSelectProps = {
     },
     input: {
       backgroundColor: 'transparent',
-      color: 'var(--mantine-color-text)',
+      color: `light-dark(${theme.colors.primary[7]}, ${theme.colors.primary[0]})`,
       border: 'none',
       height: '1.875rem',
     },
     section: {
-      color: 'var(--mantine-color-text)',
+      color: `light-dark(${theme.colors.primary[7]}, ${theme.colors.primary[0]})`,
     },
     dropdown: {
       backgroundColor: theme.colors.primary[6],

--- a/src/components/Navbar/styles.ts
+++ b/src/components/Navbar/styles.ts
@@ -22,8 +22,8 @@ export const desktopStyles = {
     isPathMatch ? theme.colors.cyan[4] : theme.colors.primary[3],
 
   linkColor: (isPathMatch: boolean) =>
-    isPathMatch ? 'var(--mantine-color-cyan-filled)' : 'var(--mantine-color-gray-text)',
-  linkStyle: {
+  isPathMatch ? 'var(--mantine-color-cyan-filled)': 'var(--mantine-color-text)',
+   linkStyle: {
     fontWeight: 700,
     padding: '.77rem',
     whiteSpace: 'nowrap',
@@ -63,7 +63,7 @@ export const mobileStyles = {
     whiteSpace: 'nowrap',
   },
   linkColor: (isPathMatch: boolean) =>
-    isPathMatch ? 'var(--mantine-color-cyan-filled)' : 'var(--mantine-color-gray-text)',
+  isPathMatch ? 'var(--mantine-color-cyan-filled)' : 'var(--mantine-color-text)',
   linkContainer: (isPathMatch: boolean) => ({
     backgroundColor: isPathMatch ? theme.colors.primary[6] : 'transparent',
     borderRadius: '0.5rem',
@@ -108,12 +108,12 @@ export const languageSelectProps = {
     },
     input: {
       backgroundColor: 'transparent',
-      color: theme.colors.primary[1],
+      color: 'var(--mantine-color-text)',
       border: 'none',
       height: '1.875rem',
     },
     section: {
-      color: theme.colors.primary[1],
+      color: 'var(--mantine-color-text)',
     },
     dropdown: {
       backgroundColor: theme.colors.primary[6],


### PR DESCRIPTION
Fixes #461

## Description
Fixes an issue where navigation links were not clearly visible in light theme due to incorrect color handling.

## Changes
- Updated navbar link color handling to use the correct theme color.
- Improved text visibility in light theme.

## Testing
- Tested light theme
- Tested dark theme
- Verified behavior after page refresh
- Passed ESLint and Storybook build
<img width="1012" height="268" alt="image" src="https://github.com/user-attachments/assets/5ad915c3-5122-471a-9cd5-c636442be108" />

<img width="903" height="252" alt="image" src="https://github.com/user-attachments/assets/4ce09a60-f908-4a29-84c9-91a281688f76" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme toggle icon visibility and consistency across light and dark modes.
  * Updated navigation and language selector text colors for improved compatibility with light and dark themes.
  * Improved readability of inactive navigation links while preserving active-link styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->